### PR TITLE
Updated links to document bookmarks

### DIFF
--- a/SharePoint/SharePointServer/upgrade-and-update/search-first-migration-from-fast-search-server-for-sharepoint-2010-to-sharepoint.md
+++ b/SharePoint/SharePointServer/upgrade-and-update/search-first-migration-from-fast-search-server-for-sharepoint-2010-to-sharepoint.md
@@ -37,7 +37,7 @@ Your organization can complete the product upgrade at any time.
   
 For more information, see:
   
-- [Search-first migration from FAST Search Server for SharePoint 2010 to SharePoint Server 2013](http://technet.microsoft.com/library/4de5887b-b6b0-42a9-a6b2-c92e6ee960d6%28Office.14%29.aspx#features_limitations)
+- [Features with limitations](#features_limitations)
     
 ## Supported migration path
 
@@ -85,7 +85,7 @@ To complete a search-first migration:
 8. On the SharePoint 2013, start crawling.
     
 > [!NOTE]
-> For information about limitations, see [Search-first migration from FAST Search Server for SharePoint 2010 to SharePoint Server 2013](http://technet.microsoft.com/library/4de5887b-b6b0-42a9-a6b2-c92e6ee960d6%28Office.14%29.aspx#features_limitations). 
+> For information about limitations, see [Search-first migration from FAST Search Server for SharePoint 2010 to SharePoint Server 2013](#features_limitations). 
   
 ## Summary of search-first migrated features
 <a name="seacrh_first_migration"> </a>
@@ -121,9 +121,9 @@ To complete a search-first migration:
 
 When you run SharePoint 2013 in mixed mode, certain features will function with limitations. You'll have to use manual workarounds for these features to work correctly. The following sections explain:
   
-- [Search-first migration from FAST Search Server for SharePoint 2010 to SharePoint Server 2013](http://technet.microsoft.com/library/4de5887b-b6b0-42a9-a6b2-c92e6ee960d6%28Office.14%29.aspx#limitations_FSS)
+- [Limitations when you migrate from FAST Search Server 2010 for SharePoint Search Center to SharePoint Server 2013](#limitations_FSS)
     
-- [Search-first migration from FAST Search Server for SharePoint 2010 to SharePoint Server 2013](http://technet.microsoft.com/library/4de5887b-b6b0-42a9-a6b2-c92e6ee960d6%28Office.14%29.aspx#limitations_after_migration)
+- [Limitations after a full migration to SharePoint Server 2013](#limitations_after_migration)
     
 ### Limitations when you migrate from FAST Search Server 2010 for SharePoint Search Center to SharePoint Server 2013
 <a name="limitations_FSS"> </a>


### PR DESCRIPTION
Bookmark links were pointing to old technet document - which was being redirected to an un related page on the new docs.* site.