### PR TITLE
Changed instructions how to handle when Feature CustomTiles is not available

### DIFF
--- a/SharePoint/SharePointServer/administration/custom-tiles-in-sharepoint-server-2016.md
+++ b/SharePoint/SharePointServer/administration/custom-tiles-in-sharepoint-server-2016.md
@@ -55,10 +55,10 @@ The custom tile feature is not enabled by default. To enable the feature, do the
   ```
 
     > [!NOTE]
-    > If the feature is not available, then you'll need to run the command: 
+    > If the feature is not available, then ensure your SharePoint farm is patched with at least Feature Pack 1 which means your patch version should be at 16.0.4456.1004 or later. You can check this by running:
   
   ```
-  Install-SPFeature -Path <path to CustomTiles>
+(Get-SPFarm).BuildVersion
   ```
 
 6. To enable the feature, at the PowerShell command prompt, type the following command:

--- a/SharePoint/SharePointServer/administration/custom-tiles-in-sharepoint-server-2016.md
+++ b/SharePoint/SharePointServer/administration/custom-tiles-in-sharepoint-server-2016.md
@@ -55,7 +55,7 @@ The custom tile feature is not enabled by default. To enable the feature, do the
   ```
 
     > [!NOTE]
-    > If the feature is not available, then ensure your SharePoint farm is patched with at least Feature Pack 1 which means your patch version should be at 16.0.4456.1004 or later. You can check this by running:
+    > If the feature is not available, then ensure your SharePoint farm is patched with at least Feature Pack 1 contained in all cumulative updates of SharePoint 2016 of November 2016 and later. To validate this, you can run the following PowerShell command. Your SharePoint build version should be at 16.0.4456.1004 or later.
   
   ```
 (Get-SPFarm).BuildVersion


### PR DESCRIPTION
The instructions stated to add the Feature CustomTiles when it was not available. This is confusing as this feature comes with Feature Pack 1 and is not just available. So I changed the instructions to validate that the SharePoint farm is patched with at least Feature Pack 1 instead.