### PR TITLE
Provided an option to prevent any page modification

### DIFF
--- a/SharePoint/SharePointOnline/let-users-create-modern-site-pages.md
+++ b/SharePoint/SharePointOnline/let-users-create-modern-site-pages.md
@@ -25,6 +25,8 @@ If you're a global or SharePoint admin in Office 365, you can allow or prevent t
   
 > [!NOTE]
 > The following procedures are for SharePoint pages only. When you allow creation of site pages, the **Add a page** command in the **Settings** menu creates new site pages. If you turn off the ability to create site pages, users can still add a SharePoint page from the **New** menu on the Home page and add from the classic page to a Wiki library using the same command. 
+>
+> If instead you want to disallow the ability for members to create or modify any kind of SharePoint page, you can change the permissions on the Site Pages library to disallow editing for users in the Members group of the site.
   
 ## Allow or prevent creation of site pages at the organization level in the SharePoint admin center
 


### PR DESCRIPTION
To me the article was confusing as I was looking for a way to prevent members to create any kind of pages. I found out that fiddling with the "Site Pages" feature only disables creation of modern pages, but still allows classic pages to be created. I don't really see in which scenario this would be useful. To provide people in the same scenario as me, so wanting to disallow any kind of page creation of modification, at least a hint towards how to accomplish this, I've added a hint towards how to do that to the notice box.