### PR TITLE
Update page "Configure server-to-server authentication between publishing and consuming farms"

### DIFF
--- a/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
+++ b/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
@@ -69,16 +69,18 @@ New-SPTrustedSecurityTokenIssuer -MetadataEndpoint "https://<ConsumeHostName>/_l
 
 ```powershell
 # Get the app principal and set required authorizations
-$centralAdminWeb = Get-SPWeb "http://<CentralAdminUrl:Port>/"
-$appPrincipal = Get-SPAppPrincipal -Site $centralAdminWeb -NameIdentifier $trustedIssuer.NameId
+$mySiteHost = Get-SPSite "http://<MySiteHostUrl/"
+$appPrincipal = Get-SPAppPrincipal -Site $mySiteHost.RootWeb -NameIdentifier $trustedIssuer.NameId
 
-# Grant app only permission and Read on the SiteSubscription
-Set-SPAppPrincipalPermission -EnableAppOnlyPolicy -AppPrincipal $appPrincipal -Site $centralAdminWeb -Scope SiteSubscription -Right Read
+# Grant permissions AppOnly and Write on the MySite host
+Set-SPAppPrincipalPermission -EnableAppOnlyPolicy -Site $mySiteHost.RootWeb -AppPrincipal $appPrincipal -Scope SiteSubscription -Right Write
 
-# Grant permissions Manage on the PrivateAPI
+# Grant permissions Manage on the PrivateAPI and Read on the SocialPermissionProvider
 $privateAPITypeId = New-Object -TypeName System.Guid ("a2ccc2e2-1703-4bd9-955f-77b2550d6f0d")
-$mgr = New-Object -TypeName Microsoft.SharePoint.SPAppPrincipalPermissionsManager ($centralAdminWeb)
+$socialPermissionProviderId = New-Object -TypeName System.Guid ("fcaec196-a98c-4f8f-b60f-e1a82272a6d2")
+$mgr = New-Object -TypeName Microsoft.SharePoint.SPAppPrincipalPermissionsManager ($mySiteHost.RootWeb)
 $mgr.AddSiteSubscriptionPermission($appPrincipal, $privateAPITypeId, [Microsoft.SharePoint.SPAppPrincipalPermissionKind]::Manage)
+$mgr.AddSiteSubscriptionPermission($appPrincipal, $socialPermissionProviderId, [Microsoft.SharePoint.SPAppPrincipalPermissionKind]::Read)
 ```
 
 ### Authorize publishing farm to send OAuth requests to the consuming farm

--- a/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
+++ b/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
@@ -13,11 +13,11 @@ ms.assetid: c77f5006-d023-463f-8256-e4570d32dd1e
 description: "Summary: Learn how to configure server-to-server authentication when you share service applications across SharePoint Server 2016 and SharePoint 2013 publishing and consuming farms."
 ---
 
-# Configure server-to-server authentication between publishing and consuming farms
+# Configure OAuth when User Profile Service Application is published
 
- **Summary:** Learn how to configure server-to-server authentication when you share service applications across SharePoint Server 2016 and SharePoint 2013 publishing and consuming farms. 
+ **Summary:** Learn how to configure OAuth when you share service applications across SharePoint Server 2016 and SharePoint 2013 publishing and consuming farms. 
   
-To enable a web application or an application service to request a resource from a web application on another farm on behalf of a user, you must configure server-to-server authentication between the farms. A few examples of SharePoint Server processes that use server-to-server authentication are as follows:
+When a farm consumes the User Profile Service Application of another farm, it will issue requests using OAuth protocol on behalf of the user for some features:
   
 - Follow a document on a Team Sites web application when a user's personal site is located on a My Sites web application. The Team Sites web application makes a request of the My Sites web application on behalf of the user.
     
@@ -37,10 +37,6 @@ To understand the procedures in this article, you should be familiar with the ba
   
 [Plan for server-to-server authentication in SharePoint Server](../security-for-sharepoint-server/plan-server-to-server-authentication.md)
 
-> [!IMPORTANT]
-> If your consuming farm has web applications that are configured or registered to a Workflow Manager, when you set a Realm value, you will need to register the Workflow Manager with the SharePoint farm. Use the PowerShell [Register-SPWorkflowService](https://docs.microsoft.com/en-us/powershell/module/sharepoint-server/register-spworkflowservice?view=sharepoint-ps) cmdlet to do this. 
-
-> For more information about setting a Realm value and registering a Workflow Manager with a SharePoint farm, see [Fix the HTTP 401 error with provider-hosted add-ins and issues with workflow and cross farm trust scenarios in SharePoint](https://support.microsoft.com/en-us/help/4010011/provider-hosted-add-ins-stop-working-and-http-401-error) and [Move Workflow Manager to a new farm in a new domain](https://sharepoint.stackexchange.com/questions/132524/move-workflow-manager-to-new-farm-in-a-new-domain).
   
 ## Configure server-to-server authentication between publishing and consuming farms
 <a name="begin"> </a>
@@ -48,8 +44,6 @@ To understand the procedures in this article, you should be familiar with the ba
 The following procedure describes how to configure server-to-server authentication between the publishing and consuming farms.
   
  **To configure server-to-server authentication between publishing and consuming farms**
-  
-1. Choose a realm name that will be common to both farms.
     
 2. Verify that you are a member of the Administrators group on the server on which you are running PowerShell cmdlets.
     

--- a/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
+++ b/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
@@ -82,7 +82,7 @@ $mgr.AddSiteSubscriptionPermission($appPrincipal, $socialPermissionProviderId, [
 
 ### Authorize publishing farm to send OAuth requests to the consuming farm
 
-1. In a SharePoint server in the publishing farms, start the SharePoint Management Shell.
+1. In a SharePoint server in the consuming farm, start the SharePoint Management Shell.
 
 2. Register the farm running User Profile service application as a trusted issuer:
 

--- a/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
+++ b/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
@@ -47,11 +47,11 @@ Verify that you are a member of the Administrators group on the servers on which
 ## Configure server-to-server authentication between publishing and consuming farms
 <a name="begin"> </a>
 
-The following procedure describes how to configure server-to-server authentication and just grant the required permissions to allow workloads to work. Each farm will keep its own authentication realm.
+The following procedure describes how to configure server-to-server authentication and grant just the necessary permissions to allow social features to work. Each farm keeps its own, unique authentication realm.
 
 ### Authorize consuming farm to send OAuth requests to the publishing farm
 
-1. In a SharePoint server in the publishing farms, start the SharePoint Management Shell.
+1. In a SharePoint server in the publishing farm, start the SharePoint Management Shell.
 
 2. Register the consuming farm as a trusted issuer:
 

--- a/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
+++ b/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
@@ -56,7 +56,7 @@ The following procedure describes how to configure server-to-server authenticati
 2. Register the consuming farm as a trusted issuer:
 
 ```powershell
-New-SPTrustedSecurityTokenIssuer -MetadataEndpoint "https://<ConsumeHostName>/_layouts/<15or16>/metadata/json/1" -Name "<ConsumeFriendlyName>"
+New-SPTrustedSecurityTokenIssuer -MetadataEndpoint "https://<ConsumingFarmHostName>/_layouts/<15or16>/metadata/json/1" -Name "<ConsumingFarmFriendlyName>"
 ```
 
     > [!NOTE]
@@ -87,7 +87,7 @@ $mgr.AddSiteSubscriptionPermission($appPrincipal, $socialPermissionProviderId, [
 2. Register the farm running User Profile service application as a trusted issuer:
 
 ```powershell
-$trustedIssuer = New-SPTrustedSecurityTokenIssuer -MetadataEndpoint "https://<PublishingHostName>/_layouts/<15or16>/metadata/json/1" -Name "<PublishingFriendlyName>"
+$trustedIssuer = New-SPTrustedSecurityTokenIssuer -MetadataEndpoint "https://<PublishingFarmHostName>/_layouts/<15or16>/metadata/json/1" -Name "<PublishingFarmFriendlyName>"
 ```
 
     > [!NOTE]

--- a/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
+++ b/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
@@ -20,11 +20,10 @@ description: "Summary: Learn how to configure server-to-server authentication wh
 When a farm consumes the User Profile service application of a publishing farm, SharePoint issues requests using Server-to-Server authentication on behalf of the user for some features:
   
 - Follow a document on a content web application when a user's personal site is located on a web application in an external farm. The content web application makes a OAuth request to the My Sites web application on behalf of the user.
-    
-- Create or reply to a site feed post for a site that is located on a content web application but performed through the user's My Site Newsfeed on the My Sites web application. The My Sites web application will make a request of the Team Sites web application on behalf of the user to write the post or the reply.
-    
-- A User Profile Service application task to repopulate the feed cache has to read from the personal site or team site. If the User Profile Service application is running in a different farm, the User Profile Service application sends a request to the My Sites web application or Team Sites web application to read the user or site feed data into the cache.
 
+- Create or reply to a site feed post for a site that is located on a content web application but performed through the user's My Site Newsfeed on the My Sites web application. The My Sites web application will make a request of the Team Sites web application on behalf of the user to write the post or the reply.
+
+- A User Profile Service application task to repopulate the feed cache has to read from the personal site or team site. If the User Profile Service application is running in a different farm, the User Profile Service application sends a request to the My Sites web application or Team Sites web application to read the user or site feed data into the cache.
   
 ## Before you begin
 <a name="begin"> </a>
@@ -38,13 +37,10 @@ To understand the procedures in this article, you should be familiar with the ba
 [Plan for server-to-server authentication in SharePoint Server](../security-for-sharepoint-server/plan-server-to-server-authentication.md)
 
 Verify that you are a member of the Administrators group on the servers on which you are running PowerShell cmdlets.
-    
-  - **Securityadmin** fixed server role on the SQL Server instance. 
-    
-  - **db_owner** fixed database role on all databases that are to be updated. 
-    
-    An administrator can use the **Add-SPShellAdmin** cmdlet to grant permissions to use SharePoint Server cmdlets. 
-    
+
+  - **Securityadmin** fixed server role on the SQL Server instance.
+  - **db_owner** fixed database role on all databases that are to be updated.
+    An administrator can use the **Add-SPShellAdmin** cmdlet to grant permissions to use SharePoint Server cmdlets.  
     > [!NOTE]
     > If you do not have permissions, contact your Setup administrator or SQL Server administrator to request permissions. For additional information about PowerShell permissions, see [Add-SPShellAdmin](http://technet.microsoft.com/library/2ddfad84-7ca8-409e-878b-d09cb35ed4aa.aspx). 
 
@@ -58,6 +54,7 @@ The following procedure describes how to configure server-to-server authenticati
 1. In a SharePoint server in the publishing farms, start the SharePoint Management Shell.
 
 2. Register the consuming farm as a trusted issuer:
+
 ```powershell
 New-SPTrustedSecurityTokenIssuer -MetadataEndpoint "https://<ConsumeHostName>/_layouts/<15or16>/metadata/json/1" -Name "<ConsumeFriendlyName>"
 ```
@@ -65,7 +62,7 @@ New-SPTrustedSecurityTokenIssuer -MetadataEndpoint "https://<ConsumeHostName>/_l
     > [!NOTE]
     > This assumes that you already added the root certificate of the consuming farm to the trusted root authorities as explained in article [Exchange trust certificates between farms in SharePoint Server](/exchange-trust-certificates-between-farms).
 
-3.Get the app principal and set required authorizations:
+3. Get the app principal and set required authorizations:
 
 ```powershell
 # Get the app principal and set required authorizations
@@ -96,7 +93,7 @@ $trustedIssuer = New-SPTrustedSecurityTokenIssuer -MetadataEndpoint "https://<Pu
     > [!NOTE]
     > This assumes that you already added the root certificate of the consuming farm to the trusted root authorities as explained in article [Exchange trust certificates between farms in SharePoint Server](/exchange-trust-certificates-between-farms).
 
-3.Get the app principal and set required authorizations:
+3. Get the app principal and set required authorizations:
 
 ```powershell
 # Get the app principal
@@ -115,9 +112,10 @@ $mgr.AddSiteSubscriptionPermission($appPrincipal, $privateAPITypeId, [Microsoft.
 ## See also
 <a name="begin"> </a>
 
-#### Concepts
+### Concepts
 
 [Share service applications across farms in SharePoint Server](share-service-applications-across-farms.md)
-#### Other Resources
+
+### Other Resources
   
 [New-SPTrustedSecurityTokenIssuer](http://technet.microsoft.com/library/9ab7aac9-4c9a-4cba-8dd6-ffead217c2fa.aspx)

--- a/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
+++ b/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
@@ -66,16 +66,16 @@ New-SPTrustedSecurityTokenIssuer -MetadataEndpoint "https://<ConsumeHostName>/_l
 
 ```powershell
 # Get the app principal and set required authorizations
-$mySiteHost = Get-SPSite "http://<MySiteHostUrl/"
-$appPrincipal = Get-SPAppPrincipal -Site $mySiteHost.RootWeb -NameIdentifier $trustedIssuer.NameId
+$mySiteHost = Get-SPWeb "http://<MySiteHostUrl/"
+$appPrincipal = Get-SPAppPrincipal -Site $mySiteHost -NameIdentifier $trustedIssuer.NameId
 
 # Grant permissions AppOnly and Write on the MySite host
-Set-SPAppPrincipalPermission -EnableAppOnlyPolicy -Site $mySiteHost.RootWeb -AppPrincipal $appPrincipal -Scope SiteSubscription -Right Write
+Set-SPAppPrincipalPermission -EnableAppOnlyPolicy -Site $mySiteHost -AppPrincipal $appPrincipal -Scope SiteSubscription -Right Write
 
 # Grant permissions Manage on the PrivateAPI and Read on the SocialPermissionProvider
 $privateAPITypeId = New-Object -TypeName System.Guid ("a2ccc2e2-1703-4bd9-955f-77b2550d6f0d")
 $socialPermissionProviderId = New-Object -TypeName System.Guid ("fcaec196-a98c-4f8f-b60f-e1a82272a6d2")
-$mgr = New-Object -TypeName Microsoft.SharePoint.SPAppPrincipalPermissionsManager ($mySiteHost.RootWeb)
+$mgr = New-Object -TypeName Microsoft.SharePoint.SPAppPrincipalPermissionsManager ($mySiteHost)
 $mgr.AddSiteSubscriptionPermission($appPrincipal, $privateAPITypeId, [Microsoft.SharePoint.SPAppPrincipalPermissionKind]::Manage)
 $mgr.AddSiteSubscriptionPermission($appPrincipal, $socialPermissionProviderId, [Microsoft.SharePoint.SPAppPrincipalPermissionKind]::Read)
 ```


### PR DESCRIPTION
Current version of the article configures all SharePoint farms to use the same authentication realm, which causes problems:
- It may cause issues with workloads that rely on OAuth (e.g. add-ins, Workflow Manager, Office Online Server).
- All farms get full trust permission between each other and can do everything on each other.

I changed the procedure to preserve the original unique authentication realm on every SharePoint farm, and set just the permissions actually required for the social features to work.