### PR TITLE
Update page "Configure server-to-server authentication between publishing and consuming farms"

### DIFF
--- a/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
+++ b/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
@@ -53,7 +53,7 @@ In a SharePoint server in the publishing farm, start the SharePoint Management S
 
 ```powershell
 # Register the consuming farm as a trusted issuer using information in its metedata file
-$trustedIssuer = New-SPTrustedSecurityTokenIssuer -MetadataEndpoint "https://<ConsumingFarmHostName>/_layouts/<15or16>/metadata/json/1" -Name "<ConsumingFarmFriendlyName>"
+$trustedIssuer = New-SPTrustedSecurityTokenIssuer -MetadataEndpoint "https://<ConsumingFarmHostName>/_layouts/15/metadata/json/1" -Name "<ConsumingFarmFriendlyName>"
 
 # Get the app principal and set required authorizations
 $mySiteHost = Get-SPWeb "http://<MySiteHostUrl/"
@@ -76,7 +76,7 @@ In a SharePoint server in the consuming farm, start the SharePoint Management Sh
 
 ```powershell
 # Register the publishing farm as a trusted issuer using information in its metedata file
-$trustedIssuer = New-SPTrustedSecurityTokenIssuer -MetadataEndpoint "https://<PublishingFarmHostName>/_layouts/<15or16>/metadata/json/1" -Name "<PublishingFarmFriendlyName>"
+$trustedIssuer = New-SPTrustedSecurityTokenIssuer -MetadataEndpoint "https://<PublishingFarmHostName>/_layouts/15/metadata/json/1" -Name "<PublishingFarmFriendlyName>"
 
 # Get the app principal
 $centralAdminWeb = Get-SPWeb "http://<CentralAdminURL/"
@@ -104,4 +104,6 @@ $mgr.AddSiteSubscriptionPermission($appPrincipal, $privateAPITypeId, [Microsoft.
 
 ### Other Resources
   
-[New-SPTrustedSecurityTokenIssuer](http://technet.microsoft.com/library/9ab7aac9-4c9a-4cba-8dd6-ffead217c2fa.aspx)
+[New-SPTrustedSecurityTokenIssuer](https://docs.microsoft.com/en-us/powershell/module/sharepoint-server/new-sptrustedsecuritytokenissuer?view=sharepoint-ps)
+
+[Set-SPAppPrincipalPermission](https://docs.microsoft.com/en-us/powershell/module/sharepoint-server/set-spappprincipalpermission?view=sharepoint-ps)

--- a/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
+++ b/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
@@ -49,7 +49,7 @@ The following procedure describes how to configure server-to-server authenticati
 
 ### Authorize consuming farm to send OAuth requests to the publishing farm
 
-In a SharePoint server in the publishing farm, start the SharePoint Management Shell and run this PowerShell script to register the consuming farm as a trusted issuer, get its app principal and grant it the required authorizations:
+In a SharePoint server in the **publishing farm**, start the SharePoint Management Shell and run this PowerShell script to register the consuming farm as a trusted issuer, get its app principal and grant it the required authorizations:
 
 ```powershell
 # Register the consuming farm as a trusted issuer using information in its metedata file
@@ -72,14 +72,14 @@ $mgr.AddSiteSubscriptionPermission($appPrincipal, $socialPermissionProviderId, [
 
 ### Authorize publishing farm to send OAuth requests to the consuming farm
 
-In a SharePoint server in the consuming farm, start the SharePoint Management Shell and run this PowerShell script to register the publishing farm as a trusted issuer, get its app principal and grant it the required authorizations:
+In a SharePoint server in the **consuming farm**, start the SharePoint Management Shell and run this PowerShell script to register the publishing farm as a trusted issuer, get its app principal and grant it the required authorizations:
 
 ```powershell
 # Register the publishing farm as a trusted issuer using information in its metedata file
 $trustedIssuer = New-SPTrustedSecurityTokenIssuer -MetadataEndpoint "https://<PublishingFarmHostName>/_layouts/15/metadata/json/1" -Name "<PublishingFarmFriendlyName>"
 
 # Get the app principal
-$centralAdminWeb = Get-SPWeb "http://<CentralAdminURL/"
+$centralAdminWeb = Get-SPWeb "http://<ConsumingFarmCentralAdminURL/"
 $appPrincipal = Get-SPAppPrincipal -Site $centralAdminWeb -NameIdentifier $trustedIssuer.NameId
 
 # Grant app only permission and Read on the SiteSubscription

--- a/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
+++ b/SharePoint/SharePointServer/administration/configure-server-to-server-authentication-in-sharepoint.md
@@ -47,13 +47,13 @@ Verify that you have the following memberships:
 
 The following procedure describes how to configure server-to-server authentication between publishing and consuming farms, and grant just the necessary permissions to allow social features to work. Each farm keeps its own, unique authentication realm.
 
-### Authorize consuming farm to send OAuth requests to the publishing farm
+### Authorize consuming farm to send OAuth requests to the farm hosting the MySites web application
 
-In a SharePoint server in the **publishing farm**, start the SharePoint Management Shell and run this PowerShell script to register the consuming farm as a trusted issuer, get its app principal and grant it the required authorizations:
+In a SharePoint server in the **farm running the MySites web application** (which might not be the publishing farm), start the SharePoint Management Shell and run this PowerShell script to register the consuming farm as a trusted issuer, get its app principal and grant it the required authorizations:
 
 ```powershell
-# Register the consuming farm as a trusted issuer using information in its metedata file
-$trustedIssuer = New-SPTrustedSecurityTokenIssuer -MetadataEndpoint "https://<ConsumingFarmHostName>/_layouts/15/metadata/json/1" -Name "<ConsumingFarmFriendlyName>"
+# Register the consuming farm as a trusted issuer using information in its metadata file
+$trustedIssuer = New-SPTrustedSecurityTokenIssuer -MetadataEndpoint "https://<ConsumingFarmWinClaimsWebApp>/_layouts/15/metadata/json/1" -Name "<ConsumingFarmFriendlyName>"
 
 # Get the app principal and set required authorizations
 $mySiteHost = Get-SPWeb "http://<MySiteHostUrl/"
@@ -75,8 +75,8 @@ $mgr.AddSiteSubscriptionPermission($appPrincipal, $socialPermissionProviderId, [
 In a SharePoint server in the **consuming farm**, start the SharePoint Management Shell and run this PowerShell script to register the publishing farm as a trusted issuer, get its app principal and grant it the required authorizations:
 
 ```powershell
-# Register the publishing farm as a trusted issuer using information in its metedata file
-$trustedIssuer = New-SPTrustedSecurityTokenIssuer -MetadataEndpoint "https://<PublishingFarmHostName>/_layouts/15/metadata/json/1" -Name "<PublishingFarmFriendlyName>"
+# Register the publishing farm as a trusted issuer using information in its metadata file
+$trustedIssuer = New-SPTrustedSecurityTokenIssuer -MetadataEndpoint "https://<PublishingFarmWinClaimsWebApp>/_layouts/15/metadata/json/1" -Name "<PublishingFarmFriendlyName>"
 
 # Get the app principal
 $centralAdminWeb = Get-SPWeb "http://<ConsumingFarmCentralAdminURL/"


### PR DESCRIPTION
Hello, this is the continuation of PR https://github.com/MicrosoftDocs/OfficeDocs-SharePoint/pull/298 with following improvements:
- Fixed a typo in the PowerShell script of the publishing farm
- Fixed 404 links
- Updated "Before you begin" chapter to add a missing prereq (Subscription Settings and App Management service applications must be up and running)
- Updated text in various places for readability
