### PR TITLE
Added uhfHeaderID to globalMetada section

### DIFF
--- a/SharePoint/docfx.json
+++ b/SharePoint/docfx.json
@@ -69,6 +69,7 @@
     "externalReference": [],
     "markdownEngineName": "markdig",    
     "globalMetadata": {
+      "uhfHeaderId": "MSDocsHeader-Dev_SharePoint",
       "breadcrumb_path": "/sharepoint/breadcrumb/toc.json",
       "extendBreadcrumb": "true",
       "searchScope": ["SharePoint Server"],


### PR DESCRIPTION
Link the SharePoint header used on dev portal to SharePoint docs.