### PR TITLE
Improve Grant-SPOHubSiteRights example

### DIFF
--- a/SharePoint/SharePointOnline/create-hub-site.md
+++ b/SharePoint/SharePointOnline/create-hub-site.md
@@ -40,7 +40,7 @@ If you're a global or SharePoint admin in Office 365, you can convert any existi
 5. When prompted with **Principals[0]**, provide the group created in step 3, or the UPN of an individual user. You can enter additional principals, one per line. Once you are finished assigning permissions, press Enter. If you want all site owners in the organization to be able to associate their sites with the hub, press Enter at the first prompt.﻿ 
     
     > [!NOTE]
-    > To restrict permission to associate sites to the hub after creation, run the following command: >  `Grant-SPOHubSiteRights -Identity -Principals GroupEmail -Rights Join`> (Where  *Identity*  is the URL of the site and  *GroupEmail*  is the email address of the mail-enabled security group.) 
+    > To restrict permission to associate sites to the hub after creation, run the following command: >  `Grant-SPOHubSiteRights -Identity URL -Principals GroupEmail -Rights Join`> (Where  *Identity*  is the URL of the site and  *GroupEmail*  is the email address of the mail-enabled security group.) 
   
 6. Notify the hub site owners that their site has been converted to a hub site.
 


### PR DESCRIPTION
In the command 
`Grant-SPOHubSiteRights -Identity -Principals GroupEmail -Rights Join`
you're showing the GroupEmail parameter, but not the URL for the -Identity. I propose changing that line to:
`Grant-SPOHubSiteRights -Identity URL -Principals GroupEmail -Rights Join`

M.