### PR TITLE
Update Upgrade-from-SharePoint2013-to-SharePointServer-2019.md

### DIFF
--- a/SharePoint/SharePointServer/upgrade-and-update/Upgrade-from-SharePoint2013-to-SharePointServer-2019.md
+++ b/SharePoint/SharePointServer/upgrade-and-update/Upgrade-from-SharePoint2013-to-SharePointServer-2019.md
@@ -50,29 +50,29 @@ For the specific, end to end steps to upgrade SharePoint 2013 to SharePoint Serv
 
 In SharePoint 2013, if you have any web applications that are in windows authentication mode, you should convert them to claims authentication. Claims authentication is the default mode in SharePoint Server 2016 and SharePoint Server 2019.
 
-Next, upgrade all the site collections from 14 mode to 15 mode by using the [Upgrade-SPSite](https://docs.microsoft.com/en-us/powershell/module/sharepoint-server/upgrade-spsite?view=sharepoint-ps) cmdlet.  Any database with a 14 version will be locked and prevented from upgrading to SharePoint Server 2016.  After the site collections have been upgraded, create a backup of all content and service application databases from your old farm (for example, SQLOLD1).  Restore these databases to a new farm’s SQL Server in SharePoint Server 2016 (for example, SQLNEW1).
+Next, upgrade all the site collections from 14 mode to 15 mode by using the [Upgrade-SPSite](https://docs.microsoft.com/en-us/powershell/module/sharepoint-server/upgrade-spsite?view=sharepoint-ps) cmdlet.  Any database with a 14 version will be locked and prevented from upgrading to SharePoint Server 2016.  After the site collections have been upgraded, create a backup of all content and service application databases from your old farm (for example, SQL2013).  Restore these databases to a new farm’s SQL Server in SharePoint Server 2016 (for example, SQL2016).
 
 ### 2016
 
-In SharePoint Server 2016, build a new farm that includes service applications. When the service applications are created use the existing database names that reside on SQLNEW1.  After the new farm is created, create a new web application with a temporary database.  Install any full trust solutions, administrator approved InfoPath forms, etc.  Dismount the temporary content database from the web application.
+In SharePoint Server 2016, build a new temporary farm that includes service applications. When the service applications are created use the existing database names that reside on SQL2016.  After the new farm is created, create a new web application with a temporary database.  Install any full trust solutions, administrator approved InfoPath forms, etc.  Dismount the temporary content database from the web application.
 
 >[!NOTE]
 >You may need to delete the temporary content database from the SQL Server.
 
-Start the upgrade process to SharePoint Server 2016 by running the [Mount-SPContentDatabase](https://docs.microsoft.com/en-us/powershell/module/sharepoint-server/mount-spcontentdatabase?view=sharepoint-ps) cmdlet on the restored content databases from SQLNEW1.  After the upgrade process is complete, perform any individual configuration changes that are not part of the service application and content databases, such as incoming/outgoing email settings, etc.
+Start the upgrade process to SharePoint Server 2016 by running the [Mount-SPContentDatabase](https://docs.microsoft.com/en-us/powershell/module/sharepoint-server/mount-spcontentdatabase?view=sharepoint-ps) cmdlet on the restored content databases from SQL2016.  After the upgrade process is complete, perform any individual configuration changes that are not part of the service application and content databases, such as incoming/outgoing email settings, etc.
 
 ### 2019
 
 The steps to upgrade from SharePoint Server 2016 to SharePoint Server 2019 are the same as going from SharePoint 2013 to SharePoint Server 2016 except for converting web applications to claims authentication and upgrading database modes to level 15. These are not required.
 
-Create a backup of all content and service application databases from your old farm (for example, SQL2016OLD1).  Restore these databases to a new farm’s SQL Server in SharePoint Server 2019 (for example, SQL2019NEW1).
+Create a backup of all content and service application databases from your temporary farm (for example, SQL2016).  Restore these databases to a new farm’s SQL Server in SharePoint Server 2019 (for example, SQL2019).
 
-In SharePoint Server 2019, build a new farm that includes service applications. When the service applications are created use the existing database names that reside on SQL2019NEW1.  After the new farm is created, create a new web application with a temporary database.  Install any full trust solutions, administrator approved InfoPath forms, etc.  Dismount the temporary content database from the web application.
+In SharePoint Server 2019, build a new farm that includes service applications. When the service applications are created use the existing database names that reside on SQL2019.  After the new farm is created, create a new web application with a temporary database.  Install any full trust solutions, administrator approved InfoPath forms, etc.  Dismount the temporary content database from the web application.
 
 >[!NOTE]
 >You may need to delete the temporary content database from the SQL Server.
 
-Start the upgrade process to SharePoint Server 2016 by running the [Mount-SPContentDatabase](https://docs.microsoft.com/en-us/powershell/module/sharepoint-server/mount-spcontentdatabase?view=sharepoint-ps) cmdlet on the restored content databases from SQLNEW1.  After the upgrade process is complete, perform any individual configuration changes that are not part of the service application and content databases, such as incoming/outgoing email settings, etc.
+Start the upgrade process to SharePoint Server 2019 by running the [Mount-SPContentDatabase](https://docs.microsoft.com/en-us/powershell/module/sharepoint-server/mount-spcontentdatabase?view=sharepoint-ps) cmdlet on the restored content databases from SQL2019.  After the upgrade process is complete, perform any individual configuration changes that are not part of the service application and content databases, such as incoming/outgoing email settings, etc.
 
 ## See Also
 


### PR DESCRIPTION
Updated the sample SQL server names for consistency, I believe the article is more clear this way.
Included the word "temporary" in the SharePoint 2016 section.
Fixed the version number in the last section.