### PR TITLE
Update configure-hybrid-sharepoint-taxonomy-and-hybrid-content-types.md

### DIFF
--- a/SharePoint/SharePointServer/hybrid/configure-hybrid-sharepoint-taxonomy-and-hybrid-content-types.md
+++ b/SharePoint/SharePointServer/hybrid/configure-hybrid-sharepoint-taxonomy-and-hybrid-content-types.md
@@ -68,6 +68,8 @@ Copying taxonomy groups is done using the Copy-SPTaxonomyGroups PowerShell cmdle
 - The URL of the location of the SharePoint Online site where your term store is located (http://\<TenantName\>.sharepoint.com).
     
 - Your Office 365 global administrator credentials.
+
+>[!NOTE] If you receive an HTTP 400 error when attempting to use the `Copy-SPTaxonomyGroups` cmdlet with correct credentials, switch to a cloud-based global administrator instead of an Active Directory synchronized account.
     
 - A list of the taxonomy groups that you want to copy.
     


### PR DESCRIPTION
Updated with a note to use a cloud only global admin if you get an HTTP 400. Addressing https://social.technet.microsoft.com/Forums/office/en-US/96f36625-056c-47c7-aa9e-d8bd7424aa3c/copysptaxonomygroups-the-remote-server-returned-an-error-400-bad-request-error-while-copying?forum=SP2016.