### PR TITLE
Update wording to include reference to KFM

### DIFF
--- a/OneDrive/network-utilization-planning.md
+++ b/OneDrive/network-utilization-planning.md
@@ -61,13 +61,15 @@ When users download locations for the first time, bandwidth usage will spike. To
 Below you can see and contrast the patterns of network utilization in cases of classic sync and when Files On-Demand functionality is enable
   
 ![OneDrive Sync Client Network Load Patterns](media/6c03ed78-0575-454a-9cf0-989c7ae7451a.png)
-  
+
 #### Operational sync
 
 After the initial sync is complete, the network usage will decrease and then level out. 
   
 > [!NOTE]
 > Network usage varies depending on file types most frequently synced. When users change Office files, only the changes are uploaded or downloaded and not the whole file. For other types of files, the whole file is uploaded or downloaded. You should expect traffic to be higher during regular work hours when users are online and working on files. 
+
+>A spike in upload traffic is expected if you deploy the Known Folder Move setting in your organization. If your organization is large and your users have a lot of files in their known folders, make sure you roll out the Group Policy objects slowly to minimize the network impact of uploading files.
   
 ## Control sync throughput
 <a name="ControlSyncThroughput"> </a>


### PR DESCRIPTION
I included an update about KFM in the "Operational sync" section. It's similar to the wording in the KFM article but seems like we should call this out here too.