### PR TITLE
Updated companies and content class rows in table

### DIFF
--- a/SharePoint/SharePointServer/technical-reference/crawled-and-managed-properties-overview.md
+++ b/SharePoint/SharePointServer/technical-reference/crawled-and-managed-properties-overview.md
@@ -49,8 +49,8 @@ The following table lists the default managed properties and their attributes. F
 |Colleagues  <br/> |Text  <br/> |Yes  <br/> |Yes  <br/> |No  <br/> |No  <br/> |No  <br/> |No  <br/> |People:Colleagues  <br/> ||
 |CombinedName  <br/> |Text  <br/> |Yes  <br/> |No  <br/> |Yes  <br/> |Yes  <br/> |No  <br/> |No  <br/> |People:CombinedName  <br/> ||
 |CombinedUserProfileNames  <br/> |Text  <br/> |No  <br/> |Yes  <br/> |No  <br/> |No  <br/> |Yes  <br/> |No  <br/> |||
-|companies  <br/> |Text  <br/> |Yes  <br/> |Yes  <br/> |No  <br/> |Yes  <br/> |Yes  <br/> |Yes  <br/> |||
-|contentclass  <br/> |Text  <br/> |No  <br/> |Yes  <br/> |No  <br/> |Yes  <br/> |Yes  <br/> |No  <br/> |DAV:contentclass, DAV:contentclass, DAV:contentclass  <br/> |DAV:contentclass  <br/> |
+|companies  <br/> |Text  <br/> |Yes  <br/> |No  <br/> |No  <br/> |Yes  <br/> |Yes  <br/> |Yes  <br/> |People:companies <br/> ||
+|contentclass  <br/> |Text  <br/> |No  <br/> |No  <br/> |No  <br/> |Yes  <br/> |Yes  <br/> |No  <br/> |DAV:contentclass, DAV:contentclass, DAV:contentclass  <br/> |DAV:contentclass  <br/> |
 |ContentModifiedTime  <br/> |Date and Time  <br/> |No  <br/> |No  <br/> |No  <br/> |Yes  <br/> |No  <br/> |No  <br/> |||
 |Contents  <br/> |Text  <br/> |No  <br/> |No  <br/> |Yes  <br/> |No  <br/> |No  <br/> |No  <br/> |ows_VideoSetDescription, ows_DocumentSetDescription, Basic:19  <br/> ||
 |ContentsHidden  <br/> |Text  <br/> |Yes  <br/> |Yes  <br/> |Yes  <br/> |No  <br/> |No  <br/> |No  <br/> |People:SPS-Location, People:Office, People:SPS-PastProjects  <br/> ||


### PR DESCRIPTION
As per Samuel Shelton (eDiscovery Dev Lead) you can't use eDiscovery to search companies and contentclass properties. The companies property is used for People search, not eDiscovery. It looks like contentclass is video related? So for both of these properties I changed the value in the "Queryable" column to "No". And for the companies property I added the value "People:companies" to the Mapped crawled properties column.