### PR TITLE
Corrected link "Introducing Send Email in Access 2013 web apps"

### DIFF
--- a/SharePoint/SharePointServer/what-s-new/new-and-improved-features-in-SharePoint-Server-2019.md
+++ b/SharePoint/SharePointServer/what-s-new/new-and-improved-features-in-SharePoint-Server-2019.md
@@ -29,7 +29,7 @@ This section provides detailed descriptions of the new updated features in Share
 
 ### Access Services 2013 now supports Send Email
 
-The Access Services 2013 service application now supports the SendEmail action for sending email messages from apps. See [Introducing Send Email in Access 2013 web apps](https://blogs.office.com/2015/01/12/introducing-send-email-access-2013-web-apps/) for more details.
+The Access Services 2013 service application now supports the SendEmail action for sending email messages from apps. See [Introducing Send Email in Access 2013 web apps](https://www.microsoft.com/en-us/microsoft-365/blog/2015/01/12/introducing-send-email-access-2013-web-apps/) for more details.
 
 ### Additional documentation links for Central Administration site
 


### PR DESCRIPTION
The "Introducing Send Email in Access 2013 web apps" link was pointing to https://blogs.office.com/2015/01/12/introducing-send-email-access-2013-web-apps/
which in turn redirects to broken link https://www.microsoft.com/en-in/microsoft-365/blog/2015/01/12/introducing-send-email-access-2013-web-apps/ 

The link is set to:
https://www.microsoft.com/en-us/microsoft-365/blog/2015/01/12/introducing-send-email-access-2013-web-apps/