### PR TITLE
Missing "Use-CacheCluster" in graceful shutdown script

### DIFF
--- a/SharePoint/SharePointServer/administration/manage-the-distributed-cache-service.md
+++ b/SharePoint/SharePointServer/administration/manage-the-distributed-cache-service.md
@@ -182,6 +182,7 @@ Use the following PowerShell script to perform a graceful shutdown of the Distri
   $currentTime = $startTime
   $elapsedTime = $currentTime - $startTime
   $timeOut = 900
+  Use-CacheCluster
   try
   {
       Write-Host "Shutting down distributed cache host."


### PR DESCRIPTION
Added the missing "Use-CacheCluster" in the graceful shutdown script