### PR TITLE
Removed SharePoint Server specific version

### DIFF
--- a/SharePoint/SharePointServer/hybrid/configure-office-365-for-sharepoint-hybrid.md
+++ b/SharePoint/SharePointServer/hybrid/configure-office-365-for-sharepoint-hybrid.md
@@ -44,11 +44,11 @@ You might have already done some of these steps. If so, there's no need to repea
   
 ## 1. Sign up for Office 365
 
-You need an [Office 365 subscription](https://go.microsoft.com/fwlink/p/?LinkID=532795) in order to set up a hybrid environment with SharePoint Server 2016. If you're planning to configure hybrid OneDrive for Business, be sure to subscribe to a plan that includes OneDrive for Business. All other hybrid SharePoint hybrid scenarios require an Enterprise plan that includes SharePoint Online. 
+You need an [Office 365 subscription](https://go.microsoft.com/fwlink/p/?LinkID=532795) in order to set up a hybrid environment with SharePoint Server. If you're planning to configure hybrid OneDrive for Business, be sure to subscribe to a plan that includes OneDrive for Business. All other hybrid SharePoint hybrid scenarios require an Enterprise plan that includes SharePoint Online. 
   
 ## 2. Register your domain with Office 365
 
-When you sign up for Office 365, you're given an initial domain name that looks like contoso.onmicrosoft.com. However, in order to configure a hybrid environment with SharePoint Server 2016, you must register a public domain that you own (such as contoso.com) in Office 365. For detailed information on how to do this, see [Work with domain names in Office 365](https://go.microsoft.com/fwlink/p/?LinkID=534807).
+When you sign up for Office 365, you're given an initial domain name that looks like contoso.onmicrosoft.com. However, in order to configure a hybrid environment with SharePoint Server, you must register a public domain that you own (such as contoso.com) in Office 365. For detailed information on how to do this, see [Work with domain names in Office 365](https://go.microsoft.com/fwlink/p/?LinkID=534807).
   
 ## 3. Assign a UPN domain suffix
 <a name="assignUPN"> </a>


### PR DESCRIPTION
On the page Configure Office 365 for SharePoint hybrid (https://docs.microsoft.com/en-us/sharepoint/hybrid/configure-office-365-for-sharepoint-hybrid)

Removed SharePoint Server specific version (i.e. 2016) from below paragraphs, as these steps are generic across all version of SharePoint Server (from 2013 onwards).
1. Sign up for Office 365
2. Register your domain with Office 365