### PR TITLE
Spelling corrections and added more information

### DIFF
--- a/SharePoint/SharePointServer/hybrid/configure-hybrid-sharepoint-taxonomy-and-hybrid-content-types.md
+++ b/SharePoint/SharePointServer/hybrid/configure-hybrid-sharepoint-taxonomy-and-hybrid-content-types.md
@@ -48,7 +48,7 @@ This video shows a walkthrough of configuring hybrid taxonomy and hybrid content
 
 If you have an existing taxonomy in SharePoint Server, the best practice is to copy any term groups you want to be part of the shared taxonomy to SharePoint Online before you configure hybrid SharePoint taxonomy. You can migrate additional taxonomy groups from SharePoint Server to SharePoint Online to add to the shared taxonomy later, but if you do you may need to run the configuration wizard again to include them in the shared taxonomy.
   
-The migration process copies taxonomy groups from SharePoint Server to SharePoint Online. This is done by using the [Copy-SPTaxonomyGroups](/powershell/module/sharepoint-server/Copy-SPTaxonomyGroups?view=sharepoint-ps) PoShell cmdlet. 
+The migration process copies taxonomy groups from SharePoint Server to SharePoint Online. This is done by using the [Copy-SPTaxonomyGroups](/powershell/module/sharepoint-server/Copy-SPTaxonomyGroups?view=sharepoint-ps) PowerShell cmdlet. 
   
  **Active Directory groups**
   
@@ -66,7 +66,9 @@ Copying taxonomy groups is done using the Copy-SPTaxonomyGroups PowerShell cmdle
     
 - The URL of the SharePoint Server site where your taxonomy store is located.
     
-- The URL of the location of the SharePoint Online site where your term store is located (http://\<TenantName\>.sharepoint.com).
+- The URL of the SharePoint Online site where your term store is located (http://\<TenantName\>.sharepoint.com).
+
+- Taxonomy groups in SharePoint Server to be copied to SharePoint Online.
     
 - Your Office 365 global administrator credentials.
 
@@ -84,7 +86,7 @@ $credential = Get-Credential
 ```
 
 ```
-Copy-SPTaxonomyGroups -LocalTermStoreName "<ManagedMetadataServiceApplicatoin>" -LocalSiteUrl "<OnPremisesSiteURL>" -RemoteSiteUrl "SharePointOnlineSiteURL" -GroupNames "Group1","Group2" -Credential $credential
+Copy-SPTaxonomyGroups -LocalTermStoreName "<ManagedMetadataServiceApplication>" -LocalSiteUrl "<OnPremisesSiteURL>" -RemoteSiteUrl "SharePointOnlineSiteURL" -GroupNames "Group1","Group2" -Credential $credential
 ```
 
 For example:


### PR DESCRIPTION
On the page https://docs.microsoft.com/en-us/sharepoint/hybrid/configure-hybrid-sharepoint-taxonomy-and-hybrid-content-types

Corrected spelling mistakes:
1. PoShell cmdlet corrected to PowerShell cmdlet
2. ManagedMetadataServiceApplicatoin to ManagedMetadataServiceApplication

Modified sentence:
"The URL of the location of the SharePoint Online site" to "The URL of the SharePoint Online site"

Under section "Copying taxonomy groups" added below point:
- Taxonomy groups in SharePoint Server to be copied to SharePoint Online.