### PR TITLE
Update external-sharing-overview.md

### DIFF
--- a/SharePoint/SharePointOnline/external-sharing-overview.md
+++ b/SharePoint/SharePointOnline/external-sharing-overview.md
@@ -86,7 +86,7 @@ Because these guests do not have a license in your organization, they are limite
     
 - They will be able to see other types of content on sites, depending on the permissions they've been given. For example, they can navigate to different subsites within a shared site. They will also be able to do things like view site feeds.
     
-If your authenticated guests need greater capability such as OneDrive storage or creating a Microsoft Flow, you must assign them an appropriate license. To do this, go to the **Active users** page of the Microsoft 365 admin center, select the guest, click **More**, and then click **Edit product licenses**.
+If your authenticated guests need greater capability such as OneDrive storage or creating a Microsoft Flow, you must assign them an appropriate license. To do this, go to the **Active users** page of the Microsoft 365 admin center, select the guest, click **More**, and then click **Edit product licenses**, Admin Center must be in standard preview.
 
  **Recipients who provide a verification code**
 


### PR DESCRIPTION
#892 
Guest user/External user adding license in Preview on do not show the show "more" or "Manage product licenses", even if you click on multiple guest user but if you click on a different user/contact user etc. it will show "Manage product licenses" then you can assign the license , but this is just a work around so you can assign the product to the guest user, you must be back to the Standard Preview in Admin Center to show the Manage Product License.

See screenshot below:
-When you click on a guest user in a Preview On
https://snag.gy/7Y3Whn.jpg

-Shows the manage product option after you click on a different user as long as it is not a guest user
https://snag.gy/RaB7oE.jpg
https://snag.gy/U6AVr1.jpg