### PR TITLE
Update what-s-new-in-sharing-in-targeted-release.md

### DIFF
--- a/SharePoint/SharePointOnline/what-s-new-in-sharing-in-targeted-release.md
+++ b/SharePoint/SharePointOnline/what-s-new-in-sharing-in-targeted-release.md
@@ -53,5 +53,8 @@ The following table shows the differences between sharing with external users wi
 |SecureLinkDeleted  <br/> |A link that only works for specific people was deleted. It is usually preceded by a series of RemovedFromSecureLink operations which signify the users who used to be secured to the link. The value in the **Detail** column for this activity identifies the UniqueSharingId for this link which can be used to match against future AddedToSecureLink and RemovedFromSecureLink operations. <br/> |
 |AddedToSecureLink  <br/> |A link that only works for specific people was secured to a user. The value in the **Detail** column for this activity identifies the name or email of the user the link was secured to and whether this user is an external user. The value also has a UniqueSharingId column that identifies the link they were secured to.  <br/> |
 |RemovedFromSecureLink  <br/> |A user was removed from a link that only works for specific people. The value in the **Detail** column for this activity identifies the name or email of the user the link was previously secured to and whether this user is an external user. The value also has a UniqueSharingId column that identifies the link they were secured to.  <br/> |
+
+> [!NOTE]
+> Secure links is a default way to allow external recipients to access files and folders securely without requiring them to create or maintain a Microsoft account. Email-based verification codes are a simple and effective way to provide secure access, familiar to users who access secure internet sites that verify identity by sending a code by email or text message.
    
 


### PR DESCRIPTION
#883 
Action Taken:
Added : " Secure links is a default way to allow external recipients to access...."
See, Introducing a new secure external sharing experience 
https://techcommunity.microsoft.com/t5/Microsoft-OneDrive-Blog/Introducing-a-new-secure-external-sharing-experience/ba-p/112624

analysis:
Secure link is always secured, used for external users to freely share a link in ODFB & SPO without compromising the security, for internal users it is automatically secured since they login with their credentials to access files.

References:
Manage sharing with external users in Office 365 Small Business
https://support.office.com/en-ie/article/manage-sharing-with-external-users-in-office-365-small-business-2951a85f-c970-4375-aa4f-6b0d7035fe35

Secure SharePoint Online sites and files
https://docs.microsoft.com/en-us/office365/securitycompliance/secure-sharepoint-online-sites-and-files

User added to secure link / Created secure link 
https://docs.microsoft.com/en-us/office365/securitycompliance/search-the-audit-log-in-security-and-compliance

Turn external sharing on or off
https://docs.microsoft.com/en-us/sharepoint/turn-external-sharing-on-or-off

Manage sharing in OneDrive and SharePoint
https://docs.microsoft.com/en-us/onedrive/manage-sharing