### PR TITLE
Update configure-ediscovery-0.md

### DIFF
--- a/SharePoint/SharePointServer/governance/configure-ediscovery-0.md
+++ b/SharePoint/SharePointServer/governance/configure-ediscovery-0.md
@@ -38,6 +38,7 @@ If you will use a SharePoint eDiscovery Center to discover content in Exchange S
 > [!IMPORTANT]
 > To discover content in Exchange Server from a SharePoint eDiscovery Center, you must be running Exchange Server 2019, 2016, or 2013. 
   
+  
 Perform the following steps:
   
 1. Ensure that the Exchange Web Service managed API is installed on every front-end server that is running SharePoint Server. 


### PR DESCRIPTION
#893 
- This has already been added " To discover content in Exchange Server from a SharePoint eDiscovery Center, you must be running Exchange Server 2019, 2015, or 2013"
-PR has been created for this issue, #945