### PR TITLE
Update deploy-intune.md

### DIFF
--- a/OneDrive/deploy-intune.md
+++ b/OneDrive/deploy-intune.md
@@ -42,9 +42,9 @@ You can use Intune to deploy the mobile apps for iOS and Android and to deploy t
 6. Select it, click **Select**, and then click **Add**.
 7. Select **Assignments** and choose the group you created. For info about this, see [How to assign apps to groups with Microsoft Intune](/intune/apps-deploy/).
 
-For more info about using Intune to deploy apps to iOS devices, see [How to add iOS store apps to Microsoft Intune](https://github.com/MicrosoftDocs/IntuneDocs/blob/master/intune/store-apps-ios.md). 
+For more information about using Intune to deploy apps to iOS devices, see [How to add iOS store apps to Microsoft Intune](https://github.com/MicrosoftDocs/IntuneDocs/blob/master/intune/store-apps-ios.md). 
 
-For more info about deploying Office 365 apps to MacOS devices using Intune, see [How to assign Office 365 to macOS devices with Microsoft Intune](https://docs.microsoft.com/intune/apps-add-office365-macos).
+For more information about deploying Office 365 apps to MacOS devices using Intune, see [How to assign Office 365 to MacOS devices with Microsoft Intune](https://docs.microsoft.com/intune/apps-add-office365-macos).
 
 ### Deploy OneDrive to Android devices by using Intune
 
@@ -59,7 +59,7 @@ For more info about deploying Office 365 apps to MacOS devices using Intune, see
 5. Select **Assignments** and choose the group you created. For info about this, see [How to assign apps to groups with Microsoft Intune](/intune/apps-deploy/).
 
 
-For more info about using Intune to deploy OneDrive to Android devices, see [How to add Android store apps to Microsoft Intune](/intune/store-apps-android). 
+For more information about using Intune to deploy OneDrive to Android devices, see [How to add Android store apps to Microsoft Intune](/intune/store-apps-android). 
 
 
 

--- a/OneDrive/deploy-intune.md
+++ b/OneDrive/deploy-intune.md
@@ -42,7 +42,9 @@ You can use Intune to deploy the mobile apps for iOS and Android and to deploy t
 6. Select it, click **Select**, and then click **Add**.
 7. Select **Assignments** and choose the group you created. For info about this, see [How to assign apps to groups with Microsoft Intune](/intune/apps-deploy/).
 
-For more info about using Intune to deploy apps to iOS devices, see [How to add iOS store apps to Microsoft Intune](/intune/store-apps-ios/). 
+For more info about using Intune to deploy apps to iOS devices, see [How to add iOS store apps to Microsoft Intune](https://github.com/MicrosoftDocs/IntuneDocs/blob/master/intune/store-apps-ios.md). 
+
+For more info about deploying Office 365 apps to MacOS devices using Intune, see [How to assign Office 365 to macOS devices with Microsoft Intune](https://docs.microsoft.com/intune/apps-add-office365-macos).
 
 ### Deploy OneDrive to Android devices by using Intune
 


### PR DESCRIPTION
#944 
-Seems that there is a different way to deploy Onedrive for business using intune to MacOs, choosing Add App as Office 365 Suite MacOs via Azure Portal
Added the link that has step by step procedure.
https://docs.microsoft.com/intune/apps-add-office365-macos

References:

Deploy and configure the new OneDrive sync client for Mac
https://docs.microsoft.com/en-us/onedrive/deploy-and-configure-on-macos

Manage OneDrive settings by using Intune
https://docs.microsoft.com/en-us/onedrive/plan-onedrive-enterprise#manage-onedrive-settings-by-using-intune

https://docs.microsoft.com/en-us/onedrive/plan-onedrive-enterprise