### PR TITLE
Update understanding-permission-levels.md

### DIFF
--- a/SharePoint/SharePointOnline/understanding-permission-levels.md
+++ b/SharePoint/SharePointOnline/understanding-permission-levels.md
@@ -99,6 +99,7 @@ You can make changes to any of the default permissions levels, except **Full Con
    
 > [!NOTE]
 > Office 365 plans create a security group called "Everyone except external users" that contains every person you add into the Office 365 directory (except people who you add explicitly as External Users). This security group added to the Members group automatically, so that users in Office 365 can access and edit the SharePoint Online site. In addition, Office 365 plans create a security group called "Company Administrators", which contains Office 365 Admins (such as Global and Billing Admins). This security group is added to the Site Collection Administrators group. 
+To learn more about "Everyone except external users" permission, see [Special SharePoint Groups](https://docs.microsoft.com/en-us/sharepoint/default-sharepoint-groups#special-sharepoint-groups)
   
 ## Permission levels and SharePoint groups
 <a name="__migbm_0"> </a>

--- a/SharePoint/SharePointOnline/understanding-permission-levels.md
+++ b/SharePoint/SharePointOnline/understanding-permission-levels.md
@@ -99,7 +99,7 @@ You can make changes to any of the default permissions levels, except **Full Con
    
 > [!NOTE]
 > Office 365 plans create a security group called "Everyone except external users" that contains every person you add into the Office 365 directory (except people who you add explicitly as External Users). This security group added to the Members group automatically, so that users in Office 365 can access and edit the SharePoint Online site. In addition, Office 365 plans create a security group called "Company Administrators", which contains Office 365 Admins (such as Global and Billing Admins). This security group is added to the Site Collection Administrators group. 
-To learn more about "Everyone except external users" permission, see [Special SharePoint Groups](https://docs.microsoft.com/en-us/sharepoint/default-sharepoint-groups#special-sharepoint-groups)
+To learn more about "Everyone except external users" permission, see [Special SharePoint Groups](https://docs.microsoft.com/sharepoint/default-sharepoint-groups#special-sharepoint-groups)
   
 ## Permission levels and SharePoint groups
 <a name="__migbm_0"> </a>


### PR DESCRIPTION
#934 
- Added article: Special SharePoint Groups 
https://docs.microsoft.com/en-us/sharepoint/default-sharepoint-groups#special-sharepoint-groups

-The Everyone except external users has it's limitation by default, this is already explained in the article:
"Everyone except external users All users added to your organization automatically become members of "Everyone except external users". Please note that you cannot change default permissions granted to "Everyone except external users" on Office 365 group-connected team sites. If a group-connected team site is set to "Public," "Everyone except external users" has a default permission level of "Edit." When a group-connected team site is set to "Private," "Everyone except external users" can't be granted any permission to the site. Although the "Site permissions" tab will allow modifications to be granted, a background job will block such modifications to take effect. To change the privacy setting for a group-connected team site, select the Settings icon, and then select Site information."

References:
https://docs.microsoft.com/en-us/sharepoint/default-sharepoint-groups#special-sharepoint-groups
https://techcommunity.microsoft.com/t5/Office-365-Groups/Default-permissions-for-Public-SharePoint-Team-Site/td-p/60639

Uservoice: 

https://office365.uservoice.com/forums/286611-office-365-groups/suggestions/11508411-group-level-view-only-permissions

https://office365.uservoice.com/forums/286611-office-365-groups/suggestions/37158241-manually-set-permissions-for-everyone-except-exte