### PR TITLE
PC - Add BlockExternalSync policy (B2BSync)

### DIFF
--- a/OneDrive/use-group-policy.md
+++ b/OneDrive/use-group-policy.md
@@ -93,7 +93,9 @@ The OneDrive Group Policy objects work by setting registry keys on the computers
 - [Prevent users from moving their Windows known folders to OneDrive](use-group-policy.md#BlockKnownFolderMove)
 
 - [Prevent users from redirecting their Windows known folders to their PC](use-group-policy.md#KFMBlockOptOut)
-    
+
+- [Prevent users from syncing libraries and folders shared from other organizations](use-group-policy.md#BlockExternalSync)
+
 - [Prevent users from syncing personal OneDrive accounts](use-group-policy.md#DisablePersonalSync)
  
 - [Prompt users to move Windows known folders to OneDrive](use-group-policy.md#KFMOptInWithWizard)
@@ -111,11 +113,11 @@ The OneDrive Group Policy objects work by setting registry keys on the computers
 - [Silently move Windows known folders to OneDrive](use-group-policy.md#KFMOptInNoWizard)
 
 - [Silently sign in users to the OneDrive sync client with their Windows credentials](use-group-policy.md#SilentAccountConfig)
- 
-> [!NOTE]
-> "Specify SharePoint Server URL and organization name" and "Specify the OneDrive location in a hybrid environment" are for customers who have SharePoint Server 2019. [More info about using the new OneDrive sync client with SharePoint Server 2019](/SharePoint/install/new-onedrive-sync-client/)
 
 - [Use OneDrive Files On-Demand](use-group-policy.md#FilesOnDemandEnabled)
+
+> [!NOTE]
+> "Specify SharePoint Server URL and organization name" and "Specify the OneDrive location in a hybrid environment" are for customers who have SharePoint Server 2019. [More info about using the new OneDrive sync client with SharePoint Server 2019](/SharePoint/install/new-onedrive-sync-client/)
 
     
 ## Computer Configuration policies
@@ -385,6 +387,19 @@ Meet Windows and OneDrive sync client requirements and still can't see Files On-
 
 [HKLM\SYSTEM\CurrentControlSet\Services\CldFlt]"Start"="dword:00000002"
 
+### Prevent users from syncing libraries and folders shared from other organizations
+<a name="BlockExternalSync"> </a>
+
+The B2B Sync feature of the OneDrive sync client allows users at an organization to sync OneDrive for Business and SharePoint libraries and folders shared with them from another organization. [Learn about OneDrive B2B Sync](b2b-sync.md).
+
+Enabling this setting will prevent users at your organization from being able to use B2B Sync. Once the setting is enabled (value 1) on a computer, the sync client will not sync libraries and folders shared from other organizations. Modify the setting to the disabled state (value 0) in order to restore B2B Sync capability for your users.
+
+prevent B2B Sync with:
+[HKLM\SOFTWARE\Policies\Microsoft\OneDrive] "BlockExternalSync"="dword:1"
+
+restore B2B Sync with:
+[HKLM\SOFTWARE\Policies\Microsoft\OneDrive] "BlockExternalSync"="dword:0"
+
 ## User Configuration policies
 <a name="Glob"> </a>
 
@@ -598,7 +613,6 @@ If you disable this setting, the local  *OneDrive - {organization name}*  folder
 > [!NOTE]
 > The %logonuser% environment variable won't work through Group Policy. We recommend you use %username% instead. 
   
-
 ## See also
 <a name="Glob"> </a>
 
@@ -610,3 +624,4 @@ If you disable this setting, the local  *OneDrive - {organization name}*  folder
   
 [Block syncing of specific file types ](block-file-types.md)
 
+[Deploy and configure the new OneDrive sync client for Mac](deploy-and-configure-on-macos.md)


### PR DESCRIPTION
Add BlockExternalSync policy for the B2BSync feature on Windows
policy friendly name is "Prevent users from syncing libraries and folders shared from other organizations"
Also added see also link at bottom to Mac deployment document where the policy is described for Mac.