### PR TITLE
Update per-machine-installation.md

### DIFF
--- a/OneDrive/per-machine-installation.md
+++ b/OneDrive/per-machine-installation.md
@@ -66,8 +66,20 @@ The sync client is an extension of the service and a very thin client so auto-up
 User intervention is not required for the per-machine sync client to update itself. Elevation is required when you first set it up. During setup, we install a scheduled task and a Windows service, which are used to perform the updates silently without user intervention since they run in elevated mode.
 
 **How do I revert back to the per-user sync client if required?** 
-We do not support automated migration from per-machine to per-user. To revert back after installing per-machine, please uninstall the sync client and [install the latest released version](https://go.microsoft.com/fwlink/?linkid=844652) without the “/allusers” parameter.  
- 
+We do not support automated migration from per-machine to per-user. To revert back after installing per-machine, please uninstall the sync client and [install the latest released version](https://go.microsoft.com/fwlink/?linkid=844652) without the “/allusers” parameter.
+
+**How can I detect the installation through SCCM?** 
+
+For SCCM, to detect the install we used the following two registry detection rules with an OR() connector;
+
+
+[HKLM\SOFTWARE\Wow6432Node\Microsoft\OneDrive]"1111-2222-3333-4444"=dword:0005000
+
+HKLM\SOFTWARE\Wow6432Node\Microsoft\OneDrive | Version | 32bit on 64bit TRUE | Type=Version | = 19.043.0304.0007
+HKLM\SOFTWARE\Microsoft\OneDrive | Version | 32bit on 64bit FALSE | Type=Version | = 19.043.0304.0007
+
+This allows the per-machine version to be detected independent of the underlying client architecture.
+
 
   
 


### PR DESCRIPTION
#937 
First Inquiry:
What does the user meant to match the old one? what article would he want to compare it to.
Since this said article is part of the "One Drive Sync", perhaps more information?

Second Inquiry answer:
Added information from the comment section #issue 937:

How can I detect the installation through SCCM.

For SCCM, to detect the install we used the following two registry detection rules with an OR() connector;

[HKLM\SOFTWARE\Wow6432Node\Microsoft\OneDrive]"1111-2222-3333-4444"=dword:0005000

HKLM\SOFTWARE\Wow6432Node\Microsoft\OneDrive | Version | 32bit on 64bit TRUE | Type=Version | = 19.043.0304.0007
HKLM\SOFTWARE\Microsoft\OneDrive | Version | 32bit on 64bit FALSE | Type=Version | = 19.043.0304.0007

This allows the per-machine version to be detected independent of the underlying client architecture.

References:

https://blogs.technet.microsoft.com/paulodias/2016/05/24/how-to-deploy-onedrive-next-generation-sync-client-with-sccm/

https://social.technet.microsoft.com/Forums/en-US/22cd9ce3-399a-4fdc-a5e8-c724216620d2/configmgr-2012-sp1-cu3-registry-key-detection-method-not-working-correctly?forum=configmanagerapps

https://serverfault.com/questions/906724/sccm-msi-deployment-fails-with-0x87d00324

https://serverfault.com/questions/625939/trying-to-detect-by-registry-after-installation-through-sccm-fails

Please feel free to let me know for any correction.