### PR TITLE
Update understanding-permission-levels.md

### DIFF
--- a/SharePoint/SharePointOnline/understanding-permission-levels.md
+++ b/SharePoint/SharePointOnline/understanding-permission-levels.md
@@ -101,8 +101,8 @@ You can make changes to any of the default permissions levels, except **Full Con
 > Office 365 plans create a security group called "Everyone except external users" that contains every person you add into the Office 365 directory (except people who you add explicitly as External Users). This security group added to the Members group automatically, so that users in Office 365 can access and edit the SharePoint Online site. In addition, Office 365 plans create a security group called "Company Administrators", which contains Office 365 Admins (such as Global and Billing Admins). This security group is added to the Site Collection Administrators group. 
 To learn more about "Everyone except external users" permission, see [Special SharePoint Groups](https://docs.microsoft.com/sharepoint/default-sharepoint-groups#special-sharepoint-groups)
 
-> [!NOTE]
-> Public and Private groups in certain Tenants may experience differing behavior such as defining permission set for "Everyone Except External Users" caused by a background job .
+> [!TIP]
+> Public and private groups in some tenants may experience different behavior, such as defining permissions set for "Everyone Except External Users", caused by a background job.
   
 ## Permission levels and SharePoint groups
 <a name="__migbm_0"> </a>

--- a/SharePoint/SharePointOnline/understanding-permission-levels.md
+++ b/SharePoint/SharePointOnline/understanding-permission-levels.md
@@ -100,6 +100,9 @@ You can make changes to any of the default permissions levels, except **Full Con
 > [!NOTE]
 > Office 365 plans create a security group called "Everyone except external users" that contains every person you add into the Office 365 directory (except people who you add explicitly as External Users). This security group added to the Members group automatically, so that users in Office 365 can access and edit the SharePoint Online site. In addition, Office 365 plans create a security group called "Company Administrators", which contains Office 365 Admins (such as Global and Billing Admins). This security group is added to the Site Collection Administrators group. 
 To learn more about "Everyone except external users" permission, see [Special SharePoint Groups](https://docs.microsoft.com/sharepoint/default-sharepoint-groups#special-sharepoint-groups)
+
+> [!NOTE]
+> Public and Private groups in certain Tenants may experience differing behavior such as defining permission set for "Everyone Except External Users" caused by a background job .
   
 ## Permission levels and SharePoint groups
 <a name="__migbm_0"> </a>


### PR DESCRIPTION
#934 
-Created an additional Note

"Public and Private groups in certain Tenants may experience differing behavior such as defining permission set for "Everyone Except External Users" caused by a background job ."

Known Issue:
https://techcommunity.microsoft.com/t5/SharePoint/Everyone-except-external-users-disappears-form-Group-Visitors/td-p/330066

Previous PR: https://github.com/MicrosoftDocs/OfficeDocs-SharePoint/pull/928