### PR TITLE
Last purple note with "AutoSave" tab should actually say "Backup" tab

### DIFF
--- a/OneDrive/redirect-known-folders.md
+++ b/OneDrive/redirect-known-folders.md
@@ -78,7 +78,7 @@ To use the following Group Policy objects, you need the OneDrive sync build 18.1
     Use this setting to force users to keep their known folders directed to OneDrive.
     
     > [!NOTE]
-    > Users can direct their known folders by opening OneDrive sync client settings, clicking the **AutoSave** tab, and then clicking **Update folders**. 
+    > Users can direct their known folders by opening OneDrive sync client settings, clicking the **Backup** tab, and then clicking **Manage backup**. 
   
 - [Prevent users from moving their Windows known folders to OneDrive](use-group-policy.md#BlockKnownFolderMove)
     


### PR DESCRIPTION
described in https://github.com/MicrosoftDocs/OfficeDocs-SharePoint/issues/1106 
the latest UI version has the Backup labels instead of auto-save