### PR TITLE
Multiple organization asset libraries on same site collection

### DIFF
--- a/SharePoint/SharePointOnline/organization-assets-library.md
+++ b/SharePoint/SharePointOnline/organization-assets-library.md
@@ -20,7 +20,7 @@ description: "Specify a library as a location for assets that are centrally stor
 If your organization needs to store and manage images like photos or logos centrally for all your users to use, you can specify one or more document libraries as an "organization assets library." This makes it easier for users to add these assets when they create SharePoint sites and pages.
 
 > [!NOTE]
-> This feature is not available for Office 365 Germany, Office 365 operated by 21Vianet (China), or Office 365 US Government plans. <br>You can specify up to 30 organization asset libraries for a single organization. 
+> This feature is not available for Office 365 Germany, Office 365 operated by 21Vianet (China), or Office 365 US Government plans. <br>You can specify up to 30 organization asset libraries for a single organization, however all of these asset libraries must reside in the same site collection. You cannot add organization asset libraries from multiple site collections.
 
 When a user adds a web part to any modern page in SharePoint and that web part opens the file picker, the user can select "Your organization" in the left pane to browse the libraries you've specified. 
 


### PR DESCRIPTION
Added notice on that you can add multiple document libraries as being organizational asset libraries, but all of these MUST reside on the same site collection or else an error will be thrown stating: "This library is not on the site that contains other organization asset libraries.". Good to point this out in the documentation.