### PR TITLE
Added UniCode Conversion note for AutoMountTeamSites

### DIFF
--- a/OneDrive/use-group-policy.md
+++ b/OneDrive/use-group-policy.md
@@ -492,6 +492,17 @@ To find the library ID, sign in as a global or SharePoint admin in Office 365, b
 
 ![The Getting ready to sync dialog box](media/copy-library-id.png)
 
+> [!NOTE]
+> The special characters in this copied string are in UniCode which needs to be converted to ASCII find and replace the following:
+> |Find |Replace|
+> |---- |-------|
+> | %2D |   -   |
+> | %7B |   {   |
+> | %7D |   }   |
+> | %3A |   :   |
+> | %2F |   /   |
+> | %2E |   .   |
+
 Enabling this policy sets the following registry key, using the entire URL from the library you copied:
 
 [HKCU\Software\Policies\Microsoft\OneDrive\TenantAutoMount]"LibraryName"="LibraryID" 


### PR DESCRIPTION
I found when configuring this setting via Intune ADMX policies that the special characters were being copied out as UniCode from the SharePoint site, while the ADMX policies either GPO or Intune need them to be ASCII.
Added a table to explain how to find and replaced the characters currently in use.