### PR TITLE
Update control-access-from-unmanaged-devices.md

### DIFF
--- a/SharePoint/SharePointOnline/control-access-from-unmanaged-devices.md
+++ b/SharePoint/SharePointOnline/control-access-from-unmanaged-devices.md
@@ -161,7 +161,7 @@ To block or limit access to specific sites, you must set the organization-wide p
     To update multiple sites at once, use the following command as an example:
 
     ```PowerShell
-    ,(Get-SPOSite -IncludePersonalSite $true -Limit all -Filter "Url -like '-my.spgrid.com/personal/") | Set-SPOTenant -ConditionalAccessPolicy AllowLimitedAccess
+    (Get-SPOSite -IncludePersonalSite $true -Limit all -Filter "Url -like '-my.sharepoint.com/personal/'") | Set-SPOTenant -ConditionalAccessPolicy AllowLimitedAccess
     ```
 
     This example gets the OneDrive for every user and passes it as an array to Set-SPOTenant to limit access. The initial comma and the parentheses are required for running this cmdlet as a batch request.


### PR DESCRIPTION
In section "Block or limit access to a specific SharePoint site or OneDrive" step 9, "To update multiple sites at once, use the following command as an example:"
Updated the cmdlet (Get-SPOSite -IncludePersonalSite) with below changes:

1. Removed leading comma from the command.
2. Corrected filter condition by adding missing ' at the end.
3. Url format is made generic as '-my.sharepoint.com/personal/'