### PR TITLE
Corrected filter condition

### DIFF
--- a/OneDrive/list-onedrive-urls.md
+++ b/OneDrive/list-onedrive-urls.md
@@ -56,7 +56,7 @@ The list you create in these steps will be saved to a text file.
     $TenantUrl = Read-Host "Enter the SharePoint Online Tenant Admin Url"
 	$LogFile = [Environment]::GetFolderPath("Desktop") + "\OneDriveSites.log"
 	Connect-SPOService -Url $TenantUrl
-	Get-SPOSite -IncludePersonalSite $true -Limit all -Filter "Url -like '-my.sharepoint.com/personal/" |select Url | Out-File $LogFile -Force
+	Get-SPOSite -IncludePersonalSite $true -Limit all -Filter "Url -like '-my.sharepoint.com/personal/'" | select Url | Out-File $LogFile -Force
 	Write-Host "Done! File saved as $($LogFile)."
      ```
 


### PR DESCRIPTION
In section "Create a list of all the OneDrive URLs in your organization using Microsoft PowerShell" step 2, "Save the following text to a PowerShell file. For example, you could save it to a file named OneDriveSites.ps1"
Updated the cmdlet (Get-SPOSite -IncludePersonalSite) with below changes:
1. Corrected filter condition by adding missing ' at the end.