### PR TITLE
Updates to Block or limit access to a specific SharePoint site or One Drive

### DIFF
--- a/SharePoint/SharePointOnline/control-access-from-unmanaged-devices.md
+++ b/SharePoint/SharePointOnline/control-access-from-unmanaged-devices.md
@@ -161,10 +161,10 @@ To block or limit access to specific sites, you must set the organization-wide p
     To update multiple sites at once, use the following command as an example:
 
     ```PowerShell
-    ,(Get-SPOSite -IncludePersonalSite $true -Limit all -Filter "Url -like '-my.spgrid.com/personal/") | Set-SPOTenant -ConditionalAccessPolicy AllowLimitedAccess
+    (Get-SPOSite -IncludePersonalSite $true -Limit all -Filter "Url -like '-my.sharepoint.com/personal/") | Set-SPOSite -ConditionalAccessPolicy AllowLimitedAccess
     ```
 
-    This example gets the OneDrive for every user and passes it as an array to Set-SPOTenant to limit access. The initial comma and the parentheses are required for running this cmdlet as a batch request.
+    This example gets the OneDrive for every user and passes it as an array to Set-SPOSite to limit access.
     
 > [!NOTE]
 > The site-level setting must be at least as restrictive as the organization-level setting. <br>By default, this policy allows users to view and edit files in their web browser. To change this, see [Advanced configurations](control-access-from-unmanaged-devices.md#advanced). 


### PR DESCRIPTION
In section "Block or limit access to a specific SharePoint site or OneDrive" step 9, "To update multiple sites at once, use the following command as an example:"
Updated the cmdlet (Get-SPOSite -IncludePersonalSite) with below changes:

1. Changed Set-SPOTenant to Set-SPOSite
![01](https://user-images.githubusercontent.com/8310319/64486541-097c4f80-d24c-11e9-95b3-2df270976032.png)

2. Removed leading comma from the command.
![02](https://user-images.githubusercontent.com/8310319/64486543-0ed99a00-d24c-11e9-964c-9cd337282406.png)

3. Corrected filter condition by adding missing ' at the end.
4. Url format is made generic as '-my.sharepoint.com/personal/'