### PR TITLE
update: correct problem with example certreq command

### DIFF
--- a/SharePoint/SharePointServer/administration/replace-the-sts-certificate.md
+++ b/SharePoint/SharePointServer/administration/replace-the-sts-certificate.md
@@ -87,7 +87,7 @@ _continue_ = "%szOID_PKIX_KP_CLIENT_AUTH%"
 From an elevated Command Prompt, run the following to create and install the certificate in the local machine store. When the certificate has been installed, a save dialog will appear. Change the Save as type to `Certificate Files` and save the file as `C:\sts.cer`.
 
 ```
-certreq -net request.inf
+certreq -new request.inf
 certutil -store My "sts.contoso.com"
 certutil -exportPFX -p "P@ssw0rd1!" CA 1f4758121a6ede8c4b81c8ca60a2d72a C:\sts.pfx
 ```


### PR DESCRIPTION
Line 90 should say 
certreq -new request.inf

-net is not a valid parameter for certreq.