### PR TITLE
Escaped character table is not formatted correctly and doesn't contai…

### DIFF
--- a/OneDrive/use-group-policy.md
+++ b/OneDrive/use-group-policy.md
@@ -493,15 +493,13 @@ To find the library ID, sign in as a global or SharePoint admin in Office 365, b
 ![The Getting ready to sync dialog box](media/copy-library-id.png)
 
 > [!NOTE]
-> The special characters in this copied string are in UniCode which needs to be converted to ASCII find and replace the following:
-> |Find |Replace|
-> |---- |-------|
-> | %2D |   -   |
-> | %7B |   {   |
-> | %7D |   }   |
-> | %3A |   :   |
-> | %2F |   /   |
-> | %2E |   .   |
+> The special characters in this copied string are escaped, any escaped characters need to be converted back to their ASCII equivalent using the following PowerShell code snippet:
+> ```
+> Add-Type -AssemblyName System.Web
+> $escapedLibraryID = "tenantId=1234s-s24s..."
+> [System.Web.HttpUtility]::UrlDecode($escapedLibraryID)
+> ```
+> Copy the output of the above snippet into the **Value** field above. 
 
 Enabling this policy sets the following registry key, using the entire URL from the library you copied:
 


### PR DESCRIPTION
…n all potential values

The escaped character table does not contain all possible values that could appear in the URL string and does not format correctly on the page.  Ideally the PowerShell function should be used instead using inbuilt functionality.