### PR TITLE
Update plan-for-disaster-recovery.md

### DIFF
--- a/SharePoint/SharePointServer/administration/plan-for-disaster-recovery.md
+++ b/SharePoint/SharePointServer/administration/plan-for-disaster-recovery.md
@@ -96,9 +96,7 @@ In a warm standby disaster recovery scenario, you create a warm standby environm
  **Virtual warm standby environments**
   
 Virtualization provides a workable and cost effective option for a warm standby recovery solution. You can use Hyper-V as an in-house solution or Azure as a hosted solution to provide necessary infrastructure for recovery.
-  
-You can create virtual images of the production servers and ship these images to the standby data center. By using the virtual standby solution, you have to make sure that the virtual images are created often enough to provide the level of farm configuration and content freshness that you must have for recovering the farm. At the secondary location, you must have an environment available in which you can easily configure and connect the images to re-create your farm environment. For more information, see [Deploying SharePoint Server 2016 with SQL Server AlwaysOn Availability Groups in Azure](deploying-sharepoint-server-2016-with-sql-server-alwayson-availability-groups-in.md)
-  
+   
 ### Hot standby recovery
 
 In a hot standby disaster recovery scenario, you set up a failover farm in the standby data center so that it can assume production operations almost immediately after the primary farm goes offline. An environment that has a separate failover farm has the following characteristics:


### PR DESCRIPTION
Line 100 describes a very fuzzy way to recover your farm from virtual machine images without explaining what types of Farm Topologies this is valid for - the method they describe would only be supported by Microsoft in case of a "single server" farm, that hosts both SharePoint and SQL on a single box, without any external data needed for the full functionality to be available.