### PR TITLE
Update the-security-token-service-is-not-available.md

### DIFF
--- a/SharePoint/SharePointServer/technical-reference/the-security-token-service-is-not-available.md
+++ b/SharePoint/SharePointServer/technical-reference/the-security-token-service-is-not-available.md
@@ -50,4 +50,4 @@ description: "Learn how to resolve the SharePoint Health Analyzer rule: The Secu
     
 **Resolution: Update the STS certificate**
 
- Confirm whether the STS certificate has expired by looking for Windows Application event log Event ID 8311 for source "SharePoint Foundation," category Topology, and with "NotTimeValid" in the message. This indicates an expired STS certificate. For assistance updating the STS certificate, please see [https://github.com/MicrosoftDocs/OfficeDocs-SharePoint/blob/live/SharePoint/SharePointServer/administration/replace-the-sts-certificate.md](Replace the STS certificate for SharePoint Server).
+ Confirm whether the STS certificate has expired by looking for Windows Application event log Event ID 8311 for source "SharePoint Foundation", category Topology, and with "NotTimeValid" in the message. This indicates an expired STS certificate. For more information on updating the STS certificate, please see [Replace the STS certificate for SharePoint Server](https://github.com/MicrosoftDocs/OfficeDocs-SharePoint/blob/live/SharePoint/SharePointServer/administration/replace-the-sts-certificate.md).

--- a/SharePoint/SharePointServer/technical-reference/the-security-token-service-is-not-available.md
+++ b/SharePoint/SharePointServer/technical-reference/the-security-token-service-is-not-available.md
@@ -24,7 +24,7 @@ description: "Learn how to resolve the SharePoint Health Analyzer rule: The Secu
   
  **Summary:** The Security Token Service is not issuing tokens. 
   
- **Cause:** The service could be malfunctioning or in a bad state, some assemblies are missing when you deploy the custom claims provider, or the STS certificate is expired. 
+ **Cause:** The service could be malfunctioning or in a bad state, some assemblies are missing when you deploy the custom claims provider, or the STS certificate has expired. 
  
   **Resolution: Restart the Security Token Service application pool.**
   

--- a/SharePoint/SharePointServer/technical-reference/the-security-token-service-is-not-available.md
+++ b/SharePoint/SharePointServer/technical-reference/the-security-token-service-is-not-available.md
@@ -24,9 +24,9 @@ description: "Learn how to resolve the SharePoint Health Analyzer rule: The Secu
   
  **Summary:** The Security Token Service is not issuing tokens. 
   
- **Cause:** The service could be malfunctioning or in a bad state, or some assemblies are missing when you deploy the custom claims provider. 
-  
- **Resolution: Restart the Security Token Service application pool.**
+ **Cause:** The service could be malfunctioning or in a bad state, some assemblies are missing when you deploy the custom claims provider, or the STS certificate is expired. 
+ 
+  **Resolution: Restart the Security Token Service application pool.**
   
 1. Verify that the user account that is performing this procedure is a member of the Farm Administrators group.
     
@@ -48,4 +48,6 @@ description: "Learn how to resolve the SharePoint Health Analyzer rule: The Secu
     
 2. Install the missing assemblies into the global assembly cache manually. For more information, see [How to: Install an Assembly into the Global Assembly Cache](https://go.microsoft.com/fwlink/p/?LinkId=169102).
     
+**Resolution: Update the STS certificate**
 
+ Confirm whether the STS certificate has expired by looking for Windows Application event log Event ID 8311 for source "SharePoint Foundation," category Topology, and with "NotTimeValid" in the message. This indicates an expired STS certificate. For assistance updating the STS certificate, please see [https://github.com/MicrosoftDocs/OfficeDocs-SharePoint/blob/live/SharePoint/SharePointServer/administration/replace-the-sts-certificate.md](Replace the STS certificate for SharePoint Server).


### PR DESCRIPTION
A third reason the STS is not available may be because it's certificate has expired. This requested file change adds guidance for spotting an expired STS certificate and where to go for information to update it.