### PR TITLE
Update link for Visual C++ 2017 redistributable

### DIFF
--- a/SharePoint/SharePointServer/install/hardware-and-software-requirements-2019.md
+++ b/SharePoint/SharePointServer/install/hardware-and-software-requirements-2019.md
@@ -226,7 +226,7 @@ In scenarios where installing prerequisites directly from the Internet is not po
 
 - [Visual C++ Redistributable Package for Visual Studio 2012](https://go.microsoft.com/fwlink/?LinkId=627156)
     
-- [Visual C++ Redistributable Package for Visual Studio 2017](https://visualstudio.microsoft.com/downloads/)
+- [Visual C++ Redistributable Package for Visual Studio 2017](https://go.microsoft.com/fwlink/?LinkId=848299)
     
 - [Exchange Web Services Managed API, version 1.2](https://go.microsoft.com/fwlink/p/?linkid=238668)
     


### PR DESCRIPTION
The "Visual C++ Redistributable Package for Visual Studio 2017" link currently points to the generic Visual Studio download page at https://visualstudio.microsoft.com/downloads/.  Now that the latest version of Visual Studio is Visual Studio 2019, it's not as easy to find how to download this package from that page - you first have to click on the "Older downloads" button to take you to https://visualstudio.microsoft.com/vs/older-downloads/, then find the "Visual C++ Redistributable Package for Visual Studio 2017" download link within that page.

To make it easier for customers to quickly find the right download, I'm updating our link to directly download the package.