### PR TITLE
Update: Onboarding Hybrid Search: add more roles that support onboarding works

### DIFF
--- a/SharePoint/SharePointServer/hybrid/configure-cloud-hybrid-searchroadmap.md
+++ b/SharePoint/SharePointServer/hybrid/configure-cloud-hybrid-searchroadmap.md
@@ -93,7 +93,10 @@ On the application server that hosts the SharePoint ServerCentral Administration
   
 1. Log on to the console as a farm administrator.
     
-2. Connect to Office 365 as a global administrator.
+2. Connect to Office 365 as one of the following roles:
+   - Global Administrator
+   - Application Administrator
+   - Cloud Application Administrator
     
 3. Navigate to [https://go.microsoft.com/fwlink/?linkid=867176](https://go.microsoft.com/fwlink/?linkid=867176) to download, install, and start the Hybrid Picker wizard. 
     


### PR DESCRIPTION
Currently, global administrator credentials are required for successfully executing the onboarding script.

However, this requirement contradicts with Microsoft's recommended best practice regarding the use of the global admin account: [https://docs.microsoft.com/en-us/azure/security/fundamentals/identity-management-best-practices#lower-exposure-of-privileged-accounts](url)

To fix that, we've updated scripts at [the download center](https://www.microsoft.com/en-us/download/details.aspx?id=51490) to support more admin roles. 
Now we want to update this documentation to provide more details for users.
