### PR TITLE
odopen URL updates and content reorganization

### DIFF
--- a/OneDrive/deploy-on-windows.md
+++ b/OneDrive/deploy-on-windows.md
@@ -127,15 +127,6 @@ To help users sign in, you can use [silent account configuration](use-silent-acc
   odopen://sync?useremail=youruseremail@organization.com
   ```
 
-If you want to auto-configure a SharePoint site to be synced, you can use the URL below as a guide to build the path to the SharePoint site you want to sync automatically. Replace HERE with the correct values for each component of the URL.
-  
-> [!NOTE]
-> Replace special characters like the period (.), hyphen (-), and at sign (@) with the corresponding encoded values. For example, if the URL includes a hyphen, replace the hyphen with its encoded value, **%2D**. Additionally, you will need Client Side Object Model (CSOM) knowledge to query the team site to determine the appropriate SiteID, WebID and ListID to build the appropriate URL. 
-  
-```
-odopen://sync/?siteId=SiteID_HERE&amp;webId=WebID_HERE&amp;listId=ListID_HERE&amp;userEmail=UserEmail_HERE&amp;webUrl=WebURL_HERE"
-```
-
 - Run the following command using Configuration Manager script:
     
   ```
@@ -150,6 +141,43 @@ odopen://sync/?siteId=SiteID_HERE&amp;webId=WebID_HERE&amp;listId=ListID_HERE&am
 
 > [!NOTE]
 > When you use Microsoft Endpoint Configuration Manager, make sure you run OneDrive.exe with User permissions (not as an Administrator). </br> For help finding your organization ID, see [Find your Microsoft 365 organization ID](find-your-office-365-tenant-id.md). 
+  
+  
+## Auto-configure Sharepoint site synchronization
+
+If you want to auto-configure a SharePoint site to be synced, you can use the URL below as a guide to build the path to the SharePoint site you want to sync automatically:
+
+```
+odopen://sync/?siteId=<siteId>&webId=<webId>&webUrl=<webURL>&listId=<listId>&userEmail=<userEmail>&webTitle=<webTitle>&listTitle=<listTitle>
+```
+where:
+- **\<siteId\>** is the SharePoint site siteId GUID, enclosed in curly brackets. You can get this GUID visiting https://\<TenantName\>.sharepoint.com/sites/\<SiteName\>/_api/site/id.
+- **\<webId\>** is the Sharepoint site webId GUID, enclosed in curly brackets. You can get this GUID visiting https://\<TenantName\>.sharepoint.com/sites/\<SiteName\>/_api/web/id.
+- **\<webUrl\>** is the Sharepoint site URL. You can get this URL visiting https://\<TenantName\>.sharepoint.com/sites/\<SiteName\>/_api/web/url.
+- **\<listId\>** is the Sharepoint site documents library GUID, enclosed in curly brackets. You can get this GUID visiting the document library in the browser, clickin the gear icon and choosing "Library Settings". The URL will show the listId GUID at the end of URL, i.e. https://\<tenant\>.sharepoint.com/sites/\<SiteName\>/_layouts/15/listedit.aspx?List=%7B**xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx**%7D (a GUID with escaped curly brackets).
+- **\<userEmail\>** is the OneDrive's user email address used to sign in into OneDrive.
+- **\<webTitle\>** and **\<listTitle\>** are used to compose the name of the local folder where the OneDrive content is synchronized. By default, when you use the "Sync" button when in the browser to synchronize a document library, OneDrive uses the  SharePoint site name and the document library name to compose the local folder name, in the form of %userprofile%\\<TenantName\>\\<SiteName\> - \<DocumentLibraryName\>. You could use any other values if you prefer to. If you do not use these parameters, the local folder will be named "<TenantName> - Documents", despite of site and library names.
+
+For example, if you want to synchronize https://contoso.sharepoint.com/sites/SalesTeam-01/ProjectX, where "ProjectX" is the documents library to synchronize, to "%userprofile%\Contoso\Sales - Unicorn" folder, you will need the following parameters to compose the odopen:// URL:
+- siteId: {ssssssss-ssss-ssss-ssss-ssssssssssss}
+- webId:  {wwwwwwww-wwww-wwww-wwww-wwwwwwwwwwww}
+- webUrl: https://contoso.sharepoint.com/sites/SalesTeam-01
+- listId: {llllllll-llll-llll-llll-llllllllllll}
+- userEmail: user@contoso.com
+- webTitle: Sales (you would use *SalesTeam-01* to mimic Sync button behavior instead)
+- listTitle: Unicorn (you would use *ProjectX* to mimic Sync button behavior instead)
+
+The resulting odopen:// URL will be:
+```
+odopen://sync/?siteId={ssssssss-ssss-ssss-ssss-ssssssssssss}&webId={wwwwwwww-wwww-wwww-wwww-wwwwwwwwwwww}&webUrl=https://contoso.sharepoint.com/sites/SalesTeam&listId={llllllll-llll-llll-llll-llllllllllll}&userEmail=user@contoso.com&Title=Sales&listTitle=Unicorn
+```
+
+> [!NOTE]
+You will need Client Side Object Model (CSOM) knowledge if you want to automate quering the team site to determine the appropriate siteId, webId and listId to build the appropriate URL. 
+
+
+
+  
   
 ## Deploy the OneDrive app on mobile devices running iOS or Android
 


### PR DESCRIPTION
The odopen:// is not sufficiently documented and in the middle of alternative mechanisms of "Help user sign in".
I put OneDrive launching mechanisms together, and created a specific odopen block with details on how to get the information neeed without CSOM, and adding webTitle and listTitle to avoid getting "<TenanName> - Documents" for every library synchronized with this method.
On the other hand, while it also works, encoding characters is not really needed, so removed the note.