### PR TITLE
SEO edits for SPMT supported features

### DIFF
--- a/migration/What-is-supported-SPMT.md
+++ b/migration/What-is-supported-SPMT.md
@@ -16,7 +16,8 @@ ms.collection:
 - M365-collaboration
 ms.custom:
 - seo-marvel-apr2020
-description: "This article contains a list of features that are supported in the SharePoint Migration Tool (SPMT)."
+- seo-marvel-jun2020
+description: In this article, learn about the supported features and locations of the SharePoint Migration Tool (SPMT).
 ---
 
 # SPMT supported features


### PR DESCRIPTION
Edited description per the SEO expert's recommendation for clarity and keywords.

There is a recommendation to add the keyword "migration tool limitations". I think that would add a negative connotation to the article, "what the SPMT can't do". This is a high-traffic keyword not addressed by other articles, so I could find a way to add it if the author's okay with it. But it would likely need to be in it's own heading that specifically called out any limitations, for which I'd need some source.