### PR TITLE
Update sharepoint-server-2016-dev-test-environment-in-azure.md

### DIFF
--- a/SharePoint/SharePointServer/administration/sharepoint-server-2016-dev-test-environment-in-azure.md
+++ b/SharePoint/SharePointServer/administration/sharepoint-server-2016-dev-test-environment-in-azure.md
@@ -220,7 +220,7 @@ $dataDisk1=New-AzDisk -DiskName ($vmName + "-SQLData") -Disk $diskConfig -Resour
 $vm=Add-AzVMDataDisk -VM $vm -Name ($vmName + "-SQLData") -CreateOption Attach -ManagedDiskId $dataDisk1.Id -Lun 1
 $cred=Get-Credential -Message "Type the name and password of the local administrator account of the SQL Server computer." 
 $vm=Set-AzVMOperatingSystem -VM $vm -Windows -ComputerName $vmName -Credential $cred -ProvisionVMAgent -EnableAutoUpdate
-$vm=Set-AzVMSourceImage -VM $vm -PublisherName MicrosoftSQLServer -Offer SQL2014SP1-WS2012R2 -Skus Standard -Version "latest"
+$vm=Set-AzVMSourceImage -VM $vm -PublisherName MicrosoftSQLServer -Offer SQL2014SP3-WS2012R2 -Skus Standard -Version "latest"
 $vm=Add-AzVMNetworkInterface -VM $vm -Id $nic.Id
 New-AzVM -ResourceGroupName $rgName -Location $locName -VM $vm
 


### PR DESCRIPTION
Changing the SQL Server image reference as original is no longer published by SQL VM PG as that Service Pack is no longer supported. Using an image with a later Service Pack.