### PR TITLE
Update mover-reports.md

### DIFF
--- a/migration/mover-reports.md
+++ b/migration/mover-reports.md
@@ -137,7 +137,7 @@ The CSV report provides the following information for each user pairing:
 
 Download an example CSV:
 
-[example_migration_report.csv](https://github.com/MicrosoftDocs/OfficeDocs-SharePoint/tree/live/migration/downloads/example_migration_report%20.csv)
+[example_migration_report.csv](downloads/example_migration_report%20.csv)
 
 ## Migration table report
 
@@ -151,7 +151,7 @@ To download this as a CSV, at the top right of the **Migration Manager**, select
 
 Download an example CSV:
 
-[example_migration_table_report.csv](https://github.com/MicrosoftDocs/OfficeDocs-SharePoint/tree/live/migration/downloads/example_migration_table_report.csv)
+[example_migration_table_report.csv](downloads/example_migration_table_report.csv)
 
 ## Migration error report
 
@@ -163,7 +163,7 @@ To download this as a CSV, at the top right of the **Migration Manager**, select
 
 Download an example CSV:
 
-[example_migration_error_report.csv](https://github.com/MicrosoftDocs/OfficeDocs-SharePoint/tree/live/migration/downloads/example_migration_error_report.csv)
+[example_migration_error_report.csv](downloads/example_migration_error_report.csv)
 
 ## Skipped files and folders
 

--- a/migration/mover-reports.md
+++ b/migration/mover-reports.md
@@ -137,7 +137,7 @@ The CSV report provides the following information for each user pairing:
 
 Download an example CSV:
 
-[example_migration_report.csv](https://github.com/MicrosoftDocs/OfficeDocs-SharePoint/tree/live/migration/downloads/example_migration_report.csv)
+[example_migration_report.csv](https://github.com/MicrosoftDocs/OfficeDocs-SharePoint/tree/live/migration/downloads/example_migration_report%20.csv)
 
 ## Migration table report
 


### PR DESCRIPTION
Example migration report has trailing space in filename (example_migration_report%20.csv), so the link was not able to open this example file. I just updated the link so that the file can be open.