### PR TITLE
Update control-access-from-unmanaged-devices.md

### DIFF
--- a/SharePoint/SharePointOnline/control-access-from-unmanaged-devices.md
+++ b/SharePoint/SharePointOnline/control-access-from-unmanaged-devices.md
@@ -183,6 +183,8 @@ Blocking access and blocking download may impact the user experience in some app
 > Apps that run in "app-only" mode in the service, like antivirus apps and search crawlers, are exempted from the policy.
 > 
 > If you're using classic SharePoint site templates, site images may not render correctly. This is because the policy prevents the original image files from being downloaded to the browser. 
+>
+> For new tenants apps using ACS app-only token is disabled by default. It is recommended to use Azure AD app-only model which is modern and securer. But you can change the behavior by running ‘set-spotenant -DisableCustomAppAuthentication $false' (need latest SharePoint admin powershel)
   
 ## Need more help?
 

--- a/SharePoint/SharePointOnline/control-access-from-unmanaged-devices.md
+++ b/SharePoint/SharePointOnline/control-access-from-unmanaged-devices.md
@@ -184,7 +184,7 @@ Blocking access and blocking download may impact the user experience in some app
 > 
 > If you're using classic SharePoint site templates, site images may not render correctly. This is because the policy prevents the original image files from being downloaded to the browser. 
 >
-> For new tenants apps using ACS app-only token is disabled by default. It is recommended to use Azure AD app-only model which is modern and securer. But you can change the behavior by running ‘set-spotenant -DisableCustomAppAuthentication $false' (need latest SharePoint admin powershel)
+> For new tenants, apps using an ACS app-only access token is disabled by default. We recommend using the Azure AD app-only model which is modern and more secure. But you can change the behavior by running ‘set-spotenant -DisableCustomAppAuthentication $false' (needs the latest SharePoint admin PowerShell).
   
 ## Need more help?
 


### PR DESCRIPTION
> For new tenants apps using ACS app-only token is disabled by default. It is recommended to use Azure AD app-only model which is modern and securer. But you can change the behavior by running ‘set-spotenant -DisableCustomAppAuthentication $false' (need latest SharePoint admin powershel)

We have added this above additional option for security.