### PR TITLE
Changing the wording for DisablingTutorial policy

### DIFF
--- a/OneDrive/use-group-policy.md
+++ b/OneDrive/use-group-policy.md
@@ -588,7 +588,7 @@ Enabling this policy sets the following registry key, using the entire URL from 
 ### Disable the tutorial that appears at the end of OneDrive Setup
 <a name="DisableFRETutorial"> </a>
 
-This setting lets you prevent the tutorial from launching in a web browser at the end of OneDrive Setup.
+This setting lets you prevent the tutorial from showing at the end of OneDrive Setup.
 
 If you enable this setting, users don't see the tutorial after they complete OneDrive Setup.
   


### PR DESCRIPTION
After we moved to a Qt FRE we no longer launch a website we show the tutorial all inline with the Setup experience.