### PR TITLE
Remove GrooveBlock information from transition-from-previous-sync-client.md

### DIFF
--- a/OneDrive/transition-from-previous-sync-client.md
+++ b/OneDrive/transition-from-previous-sync-client.md
@@ -110,14 +110,6 @@ To prevent users from using the previous OneDrive for Business sync app, follow 
     > If you installed a previous version of the SharePoint Online Management Shell, go to Add or remove programs and uninstall "SharePoint Online Management Shell." <br>On the Download Center page, select your language and then click the Download button. You'll be asked to choose between downloading a x64 and x86 .msi file. Download the x64 file if you're running the 64-bit version of Windows or the x86 file if you're running the 32-bit version. If you don't know, see [Which version of Windows operating system am I running?](https://support.microsoft.com/help/13443/windows-which-operating-system). After the file downloads, run it and follow the steps in the Setup Wizard.
 
 2. Connect to SharePoint as a [global admin or SharePoint admin](/sharepoint/sharepoint-admin-role) in Microsoft 365. To learn how, see [Getting started with SharePoint Online Management Shell](/powershell/sharepoint/sharepoint-online/connect-sharepoint-online).
-
-3. Run the following command:
-  
-    ```PowerShell
-    Set-SPOTenantSyncClientRestriction [-GrooveBlockOption <String> "OptOut"|"HardOptIn"|"SoftOptIn"] 
-    ```
-
-For more info, see [Get-SPOTenantSyncClientRestriction](/powershell/module/sharepoint-online/Get-SPOTenantSyncClientRestriction).
   
 
 ## See also  

--- a/OneDrive/transition-from-previous-sync-client.md
+++ b/OneDrive/transition-from-previous-sync-client.md
@@ -96,21 +96,6 @@ After you install and configure OneDrive.exe, Groove.exe should no longer be abl
 
 If the takeover did not succeed, the previous OneDrive for Business sync app (Groove.exe) may be an older version that can't successfully transition to the new client. To patch the previous sync app, update groove-x in [Office 2016](/officeupdates/msp-files-office-2016) or [Office 2013](/officeupdates/msp-files-office-2013), and then try again.
 
-  
-## Block the previous sync app from syncing
-
-To prevent users from using the previous OneDrive for Business sync app, follow these steps.
-
-> [!WARNING]
-> Running this command will disconnect Groove.exe even if the user is still syncing content.
-
-1. [Download the latest SharePoint Online Management Shell](https://go.microsoft.com/fwlink/p/?LinkId=255251).
-
-    > [!NOTE]
-    > If you installed a previous version of the SharePoint Online Management Shell, go to Add or remove programs and uninstall "SharePoint Online Management Shell." <br>On the Download Center page, select your language and then click the Download button. You'll be asked to choose between downloading a x64 and x86 .msi file. Download the x64 file if you're running the 64-bit version of Windows or the x86 file if you're running the 32-bit version. If you don't know, see [Which version of Windows operating system am I running?](https://support.microsoft.com/help/13443/windows-which-operating-system). After the file downloads, run it and follow the steps in the Setup Wizard.
-
-2. Connect to SharePoint as a [global admin or SharePoint admin](/sharepoint/sharepoint-admin-role) in Microsoft 365. To learn how, see [Getting started with SharePoint Online Management Shell](/powershell/sharepoint/sharepoint-online/connect-sharepoint-online).
-  
 
 ## See also  
 


### PR DESCRIPTION
GrooveBlock is no longer necessary given that the CVR will be soon enforced.
Remove the command from the instruction to discourage its usage.