### PR TITLE
Policy name can't be empty

### DIFF
--- a/SharePoint/SharePointOnline/app-enforced-restrictions.md
+++ b/SharePoint/SharePointOnline/app-enforced-restrictions.md
@@ -27,7 +27,7 @@ These steps in the Azure AD admin center tell Azure to use the SharePoint site-l
 
     ![Conditional access policies in the Azure AD admin center](media/azure-ca-new-policy.png)
 
-2. Enter a suitable name for the policy you are creating.
+2. In the **Name** box, type a name for the policy.
 
 3. Select **Users and groups**, and then select whether you want the policy to apply to all users or only select users or groups.
 

--- a/SharePoint/SharePointOnline/app-enforced-restrictions.md
+++ b/SharePoint/SharePointOnline/app-enforced-restrictions.md
@@ -27,16 +27,18 @@ These steps in the Azure AD admin center tell Azure to use the SharePoint site-l
 
     ![Conditional access policies in the Azure AD admin center](media/azure-ca-new-policy.png)
 
-2. Select **Users and groups**, and then select whether you want the policy to apply to all users or only select users or groups.
+2. Enter a suitable name for the policy you are creating.
 
-3. Select **Cloud apps or actions**, select **Select apps**, search for **SharePoint**, select **Office 365 SharePoint Online**, and then select **Select**.
+3. Select **Users and groups**, and then select whether you want the policy to apply to all users or only select users or groups.
+
+4. Select **Cloud apps or actions**, select **Select apps**, search for **SharePoint**, select **Office 365 SharePoint Online**, and then select **Select**.
 
     ![Selecting the SharePoint app](media/azure-ca-policy-cloud-app.png)
 
-4. Select **Conditions**, select **Client apps**, switch **Configure** to **Yes**, keep all the clients selected, and then select **Done**.
+5. Select **Conditions**, select **Client apps**, switch **Configure** to **Yes**, keep all the clients selected, and then select **Done**.
 
-5. Select **Session**, select **Use app enforced restrictions**, and then select **Select**. 
+6. Select **Session**, select **Use app enforced restrictions**, and then select **Select**. 
 
     ![Selecting to control access using app enforced restrictions](media/azure-ca-policy-session.png)
 
-6. Enable the policy and select **Create**.
+7. Enable the policy and select **Create**.


### PR DESCRIPTION
When following these instructions precisely there is an error at the end as you have not named the policy. This edit adds a line to tell the admin to name the policy (obvious, but it is missing).