### PR TITLE
Update versioning-content-approval-and-check-out-planning.md

### DIFF
--- a/SharePoint/SharePointServer/governance/versioning-content-approval-and-check-out-planning.md
+++ b/SharePoint/SharePointServer/governance/versioning-content-approval-and-check-out-planning.md
@@ -53,9 +53,6 @@ The default versioning control for a document library depends on the site collec
     
     Use major and minor versioning when you want to differentiate between published content that can be viewed by an audience and draft content that is not yet ready for publication. For example, on a human resources Web site that describes organizational benefits, use major and minor versioning to restrict employees' access to benefits descriptions while the descriptions are being revised.
     
-> [!NOTE]
-> When you create a new version of a document, [the incremental changes are stored in SQL Server](https://docs.microsoft.com/sql/relational-databases/track-changes/about-change-data-capture-sql-server?view=sql-server-2017), rather than a completely new copy of the document. This provides the most efficient storage and helps reduce overall storage requirements. 
-  
 ## Plan content approval
 <a name="bkmk_plan_conapprov"> </a>
 


### PR DESCRIPTION
Remove the note as it is an internal implementation rather than a concept that users or admins need to understand. It also causes confusions as the description is different from what the storage consumption and quota that users see.