### PR TITLE
Update section pertaining to Fields and their effect on the SQL query size

### DIFF
--- a/SharePoint/SharePointServer/governance/workflow-in-sharepoint-server.md
+++ b/SharePoint/SharePointServer/governance/workflow-in-sharepoint-server.md
@@ -19,5 +19,10 @@ description: "Workflows in SharePoint allow you to model and automate business p
 Workflows in SharePoint allow you to model and automate business processes. These business processes can range from simple to complex. But most importantly, workflow lets users focus on doing the work -- rather than managing the workflow.
   
 Workflows help people to collaborate on documents and to manage project tasks by implementing business processes on documents and items in a SharePoint site. Workflows help organizations adhere to consistent business processes, and improve organizational efficiency and productivity. 
-  
 
+# SharePoint 2013 Workflow and Microsoft Flow
+
+SharePoint Server 2019 supports a variety of workflow technologies to meet the needs of our customers.  These workflow technologies are described below.
+* The SharePoint 2013 Workflow platform is the recommended workflow technology for SharePoint Server 2019.  These workflows integrate with Microsoft Workflow Manager and will provide a stable and reliable workflow experience for SharePoint Server 2019.​
+* Microsoft Flow is the new cloud-based platform to automate actions across a variety of applications and services.  Thanks to hybrid technology, you can also integrate Microsoft Flow into your SharePoint Server environments using the On-Premises Data Gateway.  Each related user must be assigned a PowerApps Plan 1 license to use Flow with SharePoint Server, which is not included as part of the SharePoint Server license.  In addition, Microsoft Flow is currently optimized for non-interactive workflows with SharePoint Server.  If you require interactive workflows, we recommend exploring the SharePoint 2013 Workflow platform instead.
+* The SharePoint 2010 Workflow platform is also supported in SharePoint Server 2019 for backward compatibility.  This allows SharePoint Sever 2019 to run legacy workflows from previous versions of SharePoint Server.  Although SharePoint 2010 workflows are still supported, we don’t recommend building new workflows using this technology.  Instead, we recommend exploring either SharePoint 2013 workflows or Microsoft Flow.

--- a/SharePoint/SharePointServer/install/software-boundaries-and-limits-0.md
+++ b/SharePoint/SharePointServer/install/software-boundaries-and-limits-0.md
@@ -213,7 +213,17 @@ External Data columns have the concept of a primary column and secondary columns
     
 - Hidden Id column: A multi-line text field.
     
-- Secondary columns: Each secondary column is a text/number/Boolean/multi-line text that is based on the data type of the secondary column as defined in the Business Data Catalog model. For example, ID might be mapped to a  *Number*  column; Name might be mapped to a  *Single line of text column*  ; Description might be mapped to a  *Multiple lines of text*  column. 
+- Secondary columns: Each secondary column is a text/number/Boolean/multi-line text that is based on the data type of the secondary column as defined in the Business Data Catalog model. For example, ID might be mapped to a  *Number*  column; Name might be mapped to a  *Single line of text column*  ; Description might be mapped to a  *Multiple lines of text*  column.
+
+>[!NOTE]
+>Lists with a large number of Lookup columns may result in complex and potentially intensive SQL statements. Sharepoint will verify the length of the full SQL statement and >display this error message in case that the maximum allowed length was exceeded:
+>
+>"The list item could not be added because the length of the fields was too long. Please shorten the new entries or remove some fields from this list."
+>
+>To address this issue please reduce the number of columns of the specific list.
+>
+>In addition to standard lookup columns, single-value managed metadata, multiple-value managed metadata, single-value people and group columns, and multiple-value people and group columns count as lookup columns. 
+>Each lookup column in a list view causes a join with another table. Each additional lookup column increases the complexity and inherently the size of the backend SQL query.
     
 #### Page limits
 <a name="Page"> </a>


### PR DESCRIPTION
If a SQL query in Sharepoint exceeds a certain size, the query is dropped automatically to prevent SQL CPU spikes, and blocking queries that may ultimately bring the whole SharePoint Farm down