### PR TITLE
Removed line for Local Files

### DIFF
--- a/migration/mover-microsoft-365-faq.md
+++ b/migration/mover-microsoft-365-faq.md
@@ -22,8 +22,6 @@ description: "Frequently asked questions when using Microsoft Mover to migrate t
 Mover only migrates data from: 
 
 - An individual's **online drive storage**, such as OneDrive, MyDrive, etc.
-or
-- Data located in a **shared drive**, including Dropbox Team's Folder, SharePoint Document Library, Google Shared Drive, etc.
 
 Mover **does not** migrate e-mails, mailboxes, contacts, calendars, site layouts/collections/pages/lists, etc.
 


### PR DESCRIPTION
Mover removed the capability of migrating file shares when it was implemented into Migration Manager.  Just wanted to remove that reference.