### PR TITLE
Update discussionforums.md

### DIFF
--- a/SharePoint/SharePointOnline/includes/discussionforums.md
+++ b/SharePoint/SharePointOnline/includes/discussionforums.md
@@ -1,2 +1,2 @@
-\<Token\>    :::image type="icon" source="../media/users-group-blue-32.png" border="false"::: 
+<Token>    ![Ask a question](https://docs.microsoft.com/office/media/icons/pngs/users-group-blue-32.png) 
 If you have technical questions about this topic, you may find it helpful to post them on the [SharePoint discussion forum](https://social.technet.microsoft.com/Forums/sharepoint/home?forum=onlineservicessharepoint). It's a great resource for finding others who have worked with similar issues or who have encountered the same situation.


### PR DESCRIPTION
Reverted commit [#7a8dd1c](https://github.com/MicrosoftDocs/OfficeDocs-SharePoint/commit/7a8dd1cf2721dc5e61af8b4950973f23d482ab6f?short_path=b10d8ed) to fix the discussion forum icon displaying after plaintext `<token>`.