### PR TITLE
Update manage-search-schema.md

### DIFF
--- a/SharePoint/SharePointOnline/manage-search-schema.md
+++ b/SharePoint/SharePointOnline/manage-search-schema.md
@@ -373,49 +373,30 @@ If you need a property of a different type, or one that has different characteri
 <a name="DefaultUnusedMPs"> </a>
 
 The following table provides an overview of the default unused managed properties that you can reuse and rename using an Alias.
-  
-| **Managed property type** | **Count** |           **Managed property characteristics**           |     **Managed property name range**      |
-| :------------------------ | :-------- | :------------------------------------------------------- | :--------------------------------------- |
-| Date                      | 10        | Queryable                                                | Date00 to Date09                         |
-| Date                      | 20        | Multivalued, Queryable, Refinable, Sortable, Retrievable | RefinableDate00 to RefinableDate19       |
-| Date                      |  2        | Queryable, Refinable, Sortable, Retrievable              | RefinableDateInvariant00 to RefinableDateInvariant01 |
-| Date                      |  5        | Queryable, Refinable, Sortable, Retrievable              | RefinableDateSingle00 to RefinableDateSingle04 |
-| Decimal                   | 10        | Queryable                                                | Decimal00 to Decimal09                   |
-| Decimal                   | 10        | Multivalued, Queryable, Refinable, Sortable, Retrievable | RefinableDecimal00 to RefinableDecimal09 |
-| Double                    | 10        | Queryable                                                | Double00 to Double09                     |
-| Double                    | 10        | Multivalued, Queryable, Refinable, Sortable, Retrievable | RefinableDouble00 to RefinableDouble09   |
-| Integer                   | 50        | Queryable                                                | Int00 to Int49                           |
-| Integer                   | 50        | Multivalued, Queryable, Refinable, Sortable, Retrievable | RefinableInt00 to RefinableInt49         |
-| String                    | 200 | Multivalued, Queryable, Refinable, Sortable, Retrievable | RefinableString00 to RefinableString199  |
-
 
 | **Managed property type** | **Count** | **Multi** | **Query** | **Search** | **Retrieve** | **Refine** | **Sort** | **Managed property name range** | **Notes** |
 | :------------------------ | :-------- | :-------- | :-------- | :--------- | :----------- | :--------- | :------- |:------------------------------------------------------- | :--------------------------------------- |
-| Date                      | 10        |   -   | Query | - |     -    |    -   |   -  | Date00 to Date09                                           | [^3] [^4] |
+| Date                      | 10        |   -   | Query | - |     -    |    -   |   -  | Date00 to Date09                                           | |
 | Date                      | 20        | Multi | Query | - | Retrieve | Refine | Sort | RefinableDate00 to RefinableDate19                         | |
-| Date                      |  2        |   -   | Query | - | Retrieve | Refine | Sort | RefinableDateInvariant00 to RefinableDateInvariant01       | [^1] [^3] [^4] |
-| Date                      |  5        |   -   | Query | - | Retrieve | Refine | Sort | RefinableDateSingle00 to RefinableDateSingle04             | [^3] [^4] |
-| Decimal                   | 10        |   -   | Query | - |     -    |    -   |   -  | Decimal00 to Decimal09                                     | [^3] [^4] |
+| Date                      |  2        |   -   | Query | - | Retrieve | Refine | Sort | RefinableDateInvariant00 to RefinableDateInvariant01       | \* |
+| Date                      |  5        |   -   | Query | - | Retrieve | Refine | Sort | RefinableDateSingle00 to RefinableDateSingle04             | |
+| Decimal                   | 10        |   -   | Query | - |     -    |    -   |   -  | Decimal00 to Decimal09                                     | |
 | Decimal                   | 10        | Multi | Query | - | Retrieve | Refine | Sort | RefinableDecimal00 to RefinableDecimal09                   | |
-| Double                    | 10        |   -   | Query | - |     -    |    -   |   -  | Double00 to Double09                                       | [^3] [^4] |
+| Double                    | 10        |   -   | Query | - |     -    |    -   |   -  | Double00 to Double09                                       | |
 | Double                    | 10        | Multi | Query | - | Retrieve | Refine | Sort | RefinableDouble00 to RefinableDouble09                     | |
-| Integer                   | 50        |   -   | Query | - |     -    |    -   |   -  | Int00 to Int49                                             | [^3] [^4] |
+| Integer                   | 50        |   -   | Query | - |     -    |    -   |   -  | Int00 to Int49                                             | |
 | Integer                   | 50        | Multi | Query | - | Retrieve | Refine | Sort | RefinableInt00 to RefinableInt49                           | |
 | String                    | 200       | Multi | Query | - | Retrieve | Refine | Sort | RefinableString00 to RefinableString199                    | |
-| String                    | 40        | Multi | Query | - | Retrieve | Refine | Sort | RefinableStringFirst00 to RefinableStringFirst39           | [^1] |
-| String                    | 10        | Multi | Query | - | Retrieve | Refine | Sort | RefinableStringLn00 to RefinableStringLn09                 | [^2] |
-| String                    | 50        |   -   | Query | - | Retrieve | Refine | Sort | RefinableStringWbOff00 to RefinableStringWbOff49           | [^3] [^5] |
-| String                    | 50        | Multi | Query | - | Retrieve | Refine | Sort | RefinableStringWbOffFirst00 to RefinableStringWbOffFirst49 | [^1] [^5] |
+| String                    | 40        | Multi | Query | - | Retrieve | Refine | Sort | RefinableStringFirst00 to RefinableStringFirst39           | \* |
+| String                    | 10        | Multi | Query | - | Retrieve | Refine | Sort | RefinableStringLn00 to RefinableStringLn09                 | \*\* |
+| String                    | 50        |   -   | Query | - | Retrieve | Refine | Sort | RefinableStringWbOff00 to RefinableStringWbOff49           | \*\*\* |
+| String                    | 50        | Multi | Query | - | Retrieve | Refine | Sort | RefinableStringWbOffFirst00 to RefinableStringWbOffFirst49 | \*, \*\*\* |
 
-[^1] Mappings to crawled properties - Include content from the first crawled property that is not empty, based on the specified order.
+\* Mappings to crawled properties - Include content from the first crawled property that is not empty, based on the specified order.
 
-[^2] Language neutral word breaker
+\*\* Language neutral word breaker
 
-[^3] No multi-values
-
-[^4] Query only
-
-[^5] Complete Matching
+\*\*\* Complete Matching
 
 ## Hide documents from Delve
 

--- a/SharePoint/SharePointOnline/manage-search-schema.md
+++ b/SharePoint/SharePointOnline/manage-search-schema.md
@@ -388,19 +388,37 @@ The following table provides an overview of the default unused managed propertie
 | Integer                   | 50        | Multivalued, Queryable, Refinable, Sortable, Retrievable | RefinableInt00 to RefinableInt49         |
 | String                    | 200 | Multivalued, Queryable, Refinable, Sortable, Retrievable | RefinableString00 to RefinableString199  |
 
-Additional variants of RefinableString also exist for specific use cases. 
 
-| **Count** | **Multi** | **Query** | **Search** | **Retrieve** | **Refine** | **Sort** | **Managed property name range** | **Difference from RefinableStringXX** |
-| :-------- | :- | :- | :- | :- | :- | :- |:------------------------------------------------------- | :--------------------------------------- |
-| 40 | Y | Y | - | Y | Y | Y | RefinableStringFirst00 to RefinableStringFirst39  | Mappings to crawled properties - include content from the first crawled property that is not empty, based on the specified order. |
-| 30 | Y | Y | - | - | Y | Y | RefinableStringInternal00 to RefinableStringInternal29 | Not Retrieve |
-| 10 | Y | Y | - | Y | Y | Y | RefinableStringLn00 to RefinableStringLn09 | TBD |
-| 10 | - | Y | - | Y | Y | Y | RefinableStringSingleInternal00 to RefinableStringSingleInternal09 | Not Multi |
-| 30 | - | Y | - | - | Y | Y | RefinableStringSingleInternal10 to RefinableStringSingleInternal39 |  Not Multi, not Retrieve - note that this is the 10-39 range. |
-| 50 | - | Y | - | Y | Y | Y | RefinableStringWbOff00 to RefinableStringWbOff49 | Not Multi |
-| 50 | Y | Y | - | Y | Y | Y | RefinableStringWbOffFirst00 to RefinableStringWbOffFirst49 | Mappings to crawled properties - include content from the first crawled property that is not empty, based on the specified order. |
- 
+| **Managed property type** | **Count** | **Multi** | **Query** | **Search** | **Retrieve** | **Refine** | **Sort** | **Managed property name range** | **Notes** |
+| :------------------------ | :-------- | :-------- | :-------- | :--------- | :----------- | :--------- | :------- |:------------------------------------------------------- | :--------------------------------------- |
+| Date                      | 10        |   -   | Query | - |     -    |    -   |   -  | Date00 to Date09                                           | [^3] [^4] |
+| Date                      | 20        | Multi | Query | - | Retrieve | Refine | Sort | RefinableDate00 to RefinableDate19                         | |
+| Date                      |  2        |   -   | Query | - | Retrieve | Refine | Sort | RefinableDateInvariant00 to RefinableDateInvariant01       | [^1] [^3] [^4] |
+| Date                      |  5        |   -   | Query | - | Retrieve | Refine | Sort | RefinableDateSingle00 to RefinableDateSingle04             | [^3] [^4] |
+| Decimal                   | 10        |   -   | Query | - |     -    |    -   |   -  | Decimal00 to Decimal09                                     | [^3] [^4] |
+| Decimal                   | 10        | Multi | Query | - | Retrieve | Refine | Sort | RefinableDecimal00 to RefinableDecimal09                   | |
+| Double                    | 10        |   -   | Query | - |     -    |    -   |   -  | Double00 to Double09                                       | [^3] [^4] |
+| Double                    | 10        | Multi | Query | - | Retrieve | Refine | Sort | RefinableDouble00 to RefinableDouble09                     | |
+| Integer                   | 50        |   -   | Query | - |     -    |    -   |   -  | Int00 to Int49                                             | [^3] [^4] |
+| Integer                   | 50        | Multi | Query | - | Retrieve | Refine | Sort | RefinableInt00 to RefinableInt49                           | |
+| String                    | 200       | Multi | Query | - | Retrieve | Refine | Sort | RefinableString00 to RefinableString199                    | |
+| String                    | 40        | Multi | Query | - | Retrieve | Refine | Sort | RefinableStringFirst00 to RefinableStringFirst39           | [^1] |
+| String                    | 10        | Multi | Query | - | Retrieve | Refine | Sort | RefinableStringLn00 to RefinableStringLn09                 | [^2] |
+| String                    | 50        |   -   | Query | - | Retrieve | Refine | Sort | RefinableStringWbOff00 to RefinableStringWbOff49           | [^3] [^5] |
+| String                    | 50        | Multi | Query | - | Retrieve | Refine | Sort | RefinableStringWbOffFirst00 to RefinableStringWbOffFirst49 | [^1] [^5] |
+
+[^1] Mappings to crawled properties - Include content from the first crawled property that is not empty, based on the specified order.
+
+[^2] Language neutral word breaker
+
+[^3] No multi-values
+
+[^4] Query only
+
+[^5] Complete Matching
+
 ## Hide documents from Delve
+
 <a name="BKMK_HideFromDelveSteps"> </a>
 
 If you don't want a document to show up in Delve, you can create a HideFromDelve site column of the type **Yes/No**. This site column creates a new crawled property, ows_HideFromDelve, which is automatically mapped to the HideFromDelve managed property.

--- a/SharePoint/SharePointOnline/manage-search-schema.md
+++ b/SharePoint/SharePointOnline/manage-search-schema.md
@@ -387,7 +387,19 @@ The following table provides an overview of the default unused managed propertie
 | Integer                   | 50        | Queryable                                                | Int00 to Int49                           |
 | Integer                   | 50        | Multivalued, Queryable, Refinable, Sortable, Retrievable | RefinableInt00 to RefinableInt49         |
 | String                    | 200 | Multivalued, Queryable, Refinable, Sortable, Retrievable | RefinableString00 to RefinableString199  |
-    
+
+Additional variants of RefinableString also exist for specific use cases. 
+
+| **Count** | **Multi** | **Query** | **Search** | **Retrieve** | **Refine** | **Sort** | **Managed property name range** | **Difference from RefinableStringXX** |
+| :-------- | :- | :- | :- | :- | :- | :- |:------------------------------------------------------- | :--------------------------------------- |
+| 40 | Y | Y | - | Y | Y | Y | RefinableStringFirst00 to RefinableStringFirst39  | Mappings to crawled properties - Include content from the first crawled property that is not empty, based on the specified order |
+| 30 | Y | Y | - | - | Y | Y | RefinableStringInternal00 to RefinableStringInternal29 | Not Retrieve |
+| 10 | Y | Y | - | Y | Y | Y | RefinableStringLn00 to RefinableStringLn09 | TBD |
+| 10 | - | Y | - | Y | Y | Y | RefinableStringSingleInternal00 to RefinableStringSingleInternal09 | Not Multi |
+| 30 | - | Y | - | - | Y | Y | RefinableStringSingleInternal10 to RefinableStringSingleInternal39 |  Not Multi, not Retrieve - Note this is the 10-39 range |
+| 50 | - | Y | - | Y | Y | Y | RefinableStringWbOff00 to RefinableStringWbOff49 | Not Multi |
+| 50 | Y | Y | - | Y | Y | Y | RefinableStringWbOffFirst00 to RefinableStringWbOffFirst49 | Mappings to crawled properties - Include content from the first crawled property that is not empty, based on the specified order |
+ 
 ## Hide documents from Delve
 <a name="BKMK_HideFromDelveSteps"> </a>
 

--- a/SharePoint/SharePointOnline/manage-search-schema.md
+++ b/SharePoint/SharePointOnline/manage-search-schema.md
@@ -392,7 +392,7 @@ Additional variants of RefinableString also exist for specific use cases.
 
 | **Count** | **Multi** | **Query** | **Search** | **Retrieve** | **Refine** | **Sort** | **Managed property name range** | **Difference from RefinableStringXX** |
 | :-------- | :- | :- | :- | :- | :- | :- |:------------------------------------------------------- | :--------------------------------------- |
-| 40 | Y | Y | - | Y | Y | Y | RefinableStringFirst00 to RefinableStringFirst39  | Mappings to crawled properties - Include content from the first crawled property that is not empty, based on the specified order |
+| 40 | Y | Y | - | Y | Y | Y | RefinableStringFirst00 to RefinableStringFirst39  | Mappings to crawled properties - include content from the first crawled property that is not empty, based on the specified order. |
 | 30 | Y | Y | - | - | Y | Y | RefinableStringInternal00 to RefinableStringInternal29 | Not Retrieve |
 | 10 | Y | Y | - | Y | Y | Y | RefinableStringLn00 to RefinableStringLn09 | TBD |
 | 10 | - | Y | - | Y | Y | Y | RefinableStringSingleInternal00 to RefinableStringSingleInternal09 | Not Multi |

--- a/SharePoint/SharePointOnline/manage-search-schema.md
+++ b/SharePoint/SharePointOnline/manage-search-schema.md
@@ -398,7 +398,7 @@ Additional variants of RefinableString also exist for specific use cases.
 | 10 | - | Y | - | Y | Y | Y | RefinableStringSingleInternal00 to RefinableStringSingleInternal09 | Not Multi |
 | 30 | - | Y | - | - | Y | Y | RefinableStringSingleInternal10 to RefinableStringSingleInternal39 |  Not Multi, not Retrieve - Note this is the 10-39 range |
 | 50 | - | Y | - | Y | Y | Y | RefinableStringWbOff00 to RefinableStringWbOff49 | Not Multi |
-| 50 | Y | Y | - | Y | Y | Y | RefinableStringWbOffFirst00 to RefinableStringWbOffFirst49 | Mappings to crawled properties - Include content from the first crawled property that is not empty, based on the specified order |
+| 50 | Y | Y | - | Y | Y | Y | RefinableStringWbOffFirst00 to RefinableStringWbOffFirst49 | Mappings to crawled properties - include content from the first crawled property that is not empty, based on the specified order. |
  
 ## Hide documents from Delve
 <a name="BKMK_HideFromDelveSteps"> </a>

--- a/SharePoint/SharePointOnline/manage-search-schema.md
+++ b/SharePoint/SharePointOnline/manage-search-schema.md
@@ -396,7 +396,7 @@ Additional variants of RefinableString also exist for specific use cases.
 | 30 | Y | Y | - | - | Y | Y | RefinableStringInternal00 to RefinableStringInternal29 | Not Retrieve |
 | 10 | Y | Y | - | Y | Y | Y | RefinableStringLn00 to RefinableStringLn09 | TBD |
 | 10 | - | Y | - | Y | Y | Y | RefinableStringSingleInternal00 to RefinableStringSingleInternal09 | Not Multi |
-| 30 | - | Y | - | - | Y | Y | RefinableStringSingleInternal10 to RefinableStringSingleInternal39 |  Not Multi, not Retrieve - Note this is the 10-39 range |
+| 30 | - | Y | - | - | Y | Y | RefinableStringSingleInternal10 to RefinableStringSingleInternal39 |  Not Multi, not Retrieve - note that this is the 10-39 range. |
 | 50 | - | Y | - | Y | Y | Y | RefinableStringWbOff00 to RefinableStringWbOff49 | Not Multi |
 | 50 | Y | Y | - | Y | Y | Y | RefinableStringWbOffFirst00 to RefinableStringWbOffFirst49 | Mappings to crawled properties - include content from the first crawled property that is not empty, based on the specified order. |
  


### PR DESCRIPTION
Added a new table with variants on `RefinableString`. I chose to more closely follow the format of the UI for the **Managed property characteristics** rather than the way the table above works, since the characteristics don't match the wording or the order in the UI.

AFAIK, these variants aren't documented anywhere else, as Bingling for "RefinableStringFirst" (for example) returns zero hits.