### PR TITLE
removing Email one time passcode dependency

### DIFF
--- a/SharePoint/SharePointOnline/sharepoint-azureb2b-integration.md
+++ b/SharePoint/SharePointOnline/sharepoint-azureb2b-integration.md
@@ -49,22 +49,12 @@ This integration isn't supported in the following Microsoft 365 services:
 
 ## Enabling the integration
 
-This integration requires that your organization also enable [Azure AD email one-time passcode authentication](/azure/active-directory/b2b/one-time-passcode).
-
  > [!NOTE]
- > When the integration is enabled, people outside the organization will be invited via the Azure B2B platform when sharing from SharePoint. When the Azure B2B One Time Passcode option is enabled, recipients that don't have password-backed accounts will get a sign-in experience through Azure AD that uses One Time Passcodes. Otherwise, they will authenticate via their own Azure AD account or via an MSA account.
+ > When the integration is enabled, people outside the organization will be invited via the Azure B2B platform when sharing from SharePoint. They will sign in based on the [Azure AD B2B redemption policy](https://docs.microsoft.com/en-us/azure/active-directory/external-identities/redemption-experience#invitation-redemption-flow).
 > When the integration isn't enabled, people outside the organization will continue to use their existing accounts created when previously invited to the tenant. Any sharing to new people outside the organizaton may result in either Azure AD-backed accounts or SharePoint-only email auth guests that use a SharePoint One Time Passcode experience to sign in.
 
  >[!NOTE]
  > Review any custom [domain sharing restrictions in SharePoint and OneDrive](/sharepoint/restricted-domains-sharing) and decide if they should be moved to the [Azure AD B2B Allow/Deny list](/azure/active-directory/external-identities/allow-deny-list). The Azure AD Allow/Deny list also affects other Microsoft 365 services like Teams and Microsoft 365 Groups.
-
-To enable Azure AD passcode authentication
-1. Sign in to the [Azure portal](https://portal.azure.com) as an Azure AD Global Administrator.
-2. In the nav pane, select **Azure Active Directory**.
-3. Under **Manage**, click **External identities**.
-4. Click **All identity providers**.
-5. Under **Configured identity providers**, select **Email one-time passcode** and choose **Enable email one-time passcode for guests effective now**.
-6. Select **Save**.
 
 To enable SharePoint and OneDrive integration with Azure AD B2B
 


### PR DESCRIPTION
Email one-time passcode does not need to be enabled to turn on Azure AD B2B integration with SharePoint.