### PR TITLE
Update set-default-storage-space.md

### DIFF
--- a/SharePoint/SharePointOnline/set-default-storage-space.md
+++ b/SharePoint/SharePointOnline/set-default-storage-space.md
@@ -29,7 +29,7 @@ description: "In this article, you'll learn how to change the default storage sp
 
 For most subscription plans, the default storage space for each user's OneDrive is 1 TB. Depending on your plan and the number of licensed users, you can increase this storage up to 5 TB. For info, see the [OneDrive service description](/office365/servicedescriptions/onedrive-for-business-service-description). If you change a user's license, the available storage space is updated automatically within 24 hours after they access OneDrive.
   
-If your organization has a qualifying Microsoft 365 subscription and five (5) or more users, you can change the storage space to more than 5 TB. To discuss your needs, contact Microsoft support. Before requesting an increase you need at least 5 licenses that include OneDrive Plan 2, must assign at least one license to a user and a single user must have already filled 90% of their 5TB storage. The new storage limit is applied the next time a user accesses OneDrive.
+If your organization has a qualifying Microsoft 365 subscription and five (5) or more users, you can change the storage space to more than 5 TB. To discuss your needs, contact Microsoft support. Before requesting an increase you need at least five licenses that include OneDrive Plan 2, you must assign at least one license to a user, and a single user must have already filled 90% of their 5 TB storage. The new storage limit is applied the next time a user accesses OneDrive.
   
 > [!NOTE]
 > For help finding out which subscription you have, see [What Microsoft 365 Apps for business subscription do I have?](/office365/admin/admin-overview/what-subscription-do-i-have)

--- a/SharePoint/SharePointOnline/set-default-storage-space.md
+++ b/SharePoint/SharePointOnline/set-default-storage-space.md
@@ -29,7 +29,7 @@ description: "In this article, you'll learn how to change the default storage sp
 
 For most subscription plans, the default storage space for each user's OneDrive is 1 TB. Depending on your plan and the number of licensed users, you can increase this storage up to 5 TB. For info, see the [OneDrive service description](/office365/servicedescriptions/onedrive-for-business-service-description). If you change a user's license, the available storage space is updated automatically within 24 hours after they access OneDrive.
   
-If your organization has a qualifying Microsoft 365 subscription and five (5) or more users, you can change the storage space to more than 5 TB. To discuss your needs, contact Microsoft support. You must assign at least one license to a user before you can increase the default OneDrive storage space. The new storage limit is applied the next time a user accesses OneDrive.
+If your organization has a qualifying Microsoft 365 subscription and five (5) or more users, you can change the storage space to more than 5 TB. To discuss your needs, contact Microsoft support. Before requesting an increase you need at least 5 licenses that include OneDrive Plan 2, must assign at least one license to a user and a single user must have already filled 90% of their 5TB storage. The new storage limit is applied the next time a user accesses OneDrive.
   
 > [!NOTE]
 > For help finding out which subscription you have, see [What Microsoft 365 Apps for business subscription do I have?](/office365/admin/admin-overview/what-subscription-do-i-have)


### PR DESCRIPTION
It does not clearly state that tenant requires 5 eligible licenses as we have it in internal wiki https://supportability.visualstudio.com/ModernStack/_wiki/wikis/ModernKB/491336/Increase-OneDrive-Storage-Beyond-5TB.  It would be nice to see this clearly explained so that our customers are well informed.