### PR TITLE
Add missing step Update-SPFlightsConfigFile when creating farm using PowerShell

### DIFF
--- a/SharePoint/SharePointServer/install/installing-sharepoint-server-subscription-edition-on-windows-server-core.md
+++ b/SharePoint/SharePointServer/install/installing-sharepoint-server-subscription-edition-on-windows-server-core.md
@@ -71,12 +71,13 @@ Perform the following steps to install SharePoint Server Subscription Edition on
 11. Run the following SharePoint PowerShell cmdlets with their appropriate parameters to create or join a farm.
 
     1. `New-SPConfigurationDatabase` to create a farm or `Connect-SPConfigurationDatabase` to join a farm.
-    2. `Install-SPHelpCollection -All`
-    3. `Initialize-SPResourceSecurity`
-    4. `Install-SPService`
-    5. `Install-SPFeature -AllExistingFeatures`
-    6. `New-SPCentralAdministration`
-    7. `Install-SPApplicationContent`
+    2. `Update-SPFlightsConfigFile -FilePath "C:\Program Files\Common Files\microsoft shared\Web Server Extensions\16\CONFIG\SPFlightRawConfig.json"`
+    3. `Install-SPHelpCollection -All`
+    4. `Initialize-SPResourceSecurity`
+    5. `Install-SPService`
+    6. `Install-SPFeature -AllExistingFeatures`
+    7. `New-SPCentralAdministration`
+    8. `Install-SPApplicationContent`
 
     > [!Note]
     > You can also use the `PSCONFIG.EXE` command line tool or the `PSConfigUI.exe` GUI tool. However, `PSConfigUI.exe` will crash on Windows Server Core if it needs to display a summary of error messages at the end of the sequence due to a dependency on HTML rendering components.

--- a/SharePoint/SharePointServer/install/installing-sharepoint-server-subscription-edition-on-windows-server-core.md
+++ b/SharePoint/SharePointServer/install/installing-sharepoint-server-subscription-edition-on-windows-server-core.md
@@ -4,7 +4,7 @@ ms.reviewer:
 ms.author: v-nsatapathy
 author: nimishasatapathy
 manager: serdars
-ms.date: 06/23/2021
+ms.date: 04/27/2023
 audience: ITPro
 f1.keywords:
 - NOCSH

--- a/SharePoint/SharePointServer/install/repair-sharepoint-server-subscription-edition.md
+++ b/SharePoint/SharePointServer/install/repair-sharepoint-server-subscription-edition.md
@@ -4,7 +4,7 @@ ms.reviewer:
 ms.author: v-nsatapathy
 author: nimishasatapathy
 manager: serdars
-ms.date: 6/24/2021
+ms.date: 4/27/2023
 audience: ITPro
 f1.keywords:
 - NOCSH
@@ -74,12 +74,13 @@ SharePoint Server repair steps are as follows:
 
 3. Run the following SharePoint PowerShell cmdlets with their appropriate parameters to repair the server in the farm.
 
-    1. `Install-SPHelpCollection -All`
-    2. `Initialize-SPResourceSecurity`
-    3. `Install-SPService`
-    4. `Install-SPFeature -AllExistingFeatures`
-    5. `New-SPCentralAdministration` (If hosting the Central Administration site on this server)
-    6. `Install-SPApplicationContent`
+    1. `Update-SPFlightsConfigFile -FilePath "C:\Program Files\Common Files\microsoft shared\Web Server Extensions\16\CONFIG\SPFlightRawConfig.json"`
+    2. `Install-SPHelpCollection -All`
+    3. `Initialize-SPResourceSecurity`
+    4. `Install-SPService`
+    5. `Install-SPFeature -AllExistingFeatures`
+    6. `New-SPCentralAdministration` (If hosting the Central Administration site on this server)
+    7. `Install-SPApplicationContent`
 
     > [!Note]
     > You can also use the `PSCONFIG.EXE` command line tool or the `PSConfigUI.exe` GUI tool. However, `PSConfigUI.exe` will crash on Windows Server Core if it needs to display a summary of error messages at the end of the sequence due to a dependency on HTML rendering components.


### PR DESCRIPTION
SharePoint Subscription introduced flighting, and each update comes with a new set of flights to activate / deactivate.
When using psconfigui.exe, the new set of flights is updated automatically, but when using PowerShell, it must be done explicitly by calling cmdlet [`Update-SPFlightsConfigFile`](https://learn.microsoft.com/powershell/module/sharepoint-server/update-spflightsconfigfile?view=sharepoint-server-ps).
This PR updated both relevant articles to include this step.
