### PR TITLE
Update use-group-policy.md

### DIFF
--- a/SharePoint/SharePointOnline/use-group-policy.md
+++ b/SharePoint/SharePointOnline/use-group-policy.md
@@ -544,6 +544,9 @@ If you don't set any of the following policies, then the default policy will mov
 
 `[HKLM\SOFTWARE\Policies\Microsoft\OneDrive]"KFMSilentOptInPictures"=dword:00000001`: Setting this value to **1** will move the Pictures folder.
 
+> [!IMPORTANT]
+> The Group Policy object **User Configuration** > **Administrative Templates** > **Desktop** > **Prohibit User from manually redirecting Profile Folders** must be set to **Disabled** or **Not configured**. Folders will not move to OneDrive if set to **Enabled**.
+
 For more information, see [Redirect and move Windows known folders to OneDrive](redirect-known-folders.md).
   
 ### Silently sign in users to the OneDrive sync app with their Windows credentials


### PR DESCRIPTION
Appended information under "Silently move Windows known folders to OneDrive" subheading advising conflict with "Prohibit User from manually redirecting Profile Folders" Group Policy object and "Known Folder Move".

> The Group Policy object **User Configuration** > **Administrative Templates** > **Desktop** > **Prohibit User from manually redirecting Profile Folders** must be set to **Disabled** or **Not configured**. Folders will not move to OneDrive if set to **Enabled**.

When this Group Policy object is applied, OneDrive will not move folders specified in the registry with no indication to the user a policy conflict has occurred. The policy is commonplace in corporate Active Directory networks and would be a beneficial detail within the documentation.