### PR TITLE
Update restricted-sharepoint-search-admin-scripts.md with correct syn…

### DIFF
--- a/SharePoint/SharePointOnline/restricted-sharepoint-search-admin-scripts.md
+++ b/SharePoint/SharePointOnline/restricted-sharepoint-search-admin-scripts.md
@@ -146,7 +146,7 @@ Add-SPOTenantRestrictedSearchAllowedList -SitesListFileUrl <string> [-ContainsHe
  **Example 1**
 
 ```powershell
-Add-SPOTenantRestrictedSearchAllowedList -SitesList @(“[https://contoso.sharepoint.com/sites/Marketing](https://contoso.sharepoint.com/sites/Marketing)”, “[https://contoso.sharepoint.com/sites/Benefits](https://contoso.sharepoint.com/sites/Benefits)”)
+Add-SPOTenantRestrictedSearchAllowedList -SitesList @("https://contoso.sharepoint.com/sites/Marketing", "https://contoso.sharepoint.com/sites/Benefits")
 ```
 
 This example lets the admin add the sites to the allowed list.


### PR DESCRIPTION
…tax for example code

Fixing Add-SPOTenantRestrictedSearchAllowedList -SitesList "Example 1" to use proper syntax for the string array of URLs. Previous version appears to be using markdown link syntax for some reason. (It also had "smart quotes" instead of normal quotes.)