### PR TITLE
added a limitation on replacing site.

### DIFF
--- a/SharePoint/SharePointOnline/modern-root-site.md
+++ b/SharePoint/SharePointOnline/modern-root-site.md
@@ -70,6 +70,7 @@ If you've [turned on audit log search](/office365/securitycompliance/turn-audit-
 - Replacing the root site with another site replaces the entire site collection with the new site collection. If your current root site has subsites, they'll be archived. 
 - The site you select as the new root site must be within the same domain as the current root site.
 - If the site is on hold, you'll receive an informative error and you can't replace the site.
+- You as admin must be a member of the site that you are replacing.
   
 ### Use the new SharePoint admin center
 


### PR DESCRIPTION
Spent the last day on this issue regarding `Replace Site` functionality.

Turns out that if you are not a member of the site that you are trying to replace you end up getting the following error.

<img width="559" alt="image" src="https://github.com/user-attachments/assets/ebafc111-262d-4752-a5ca-034ba510cf5b">

![CleanShot 2024-10-25 at 09 58 08@2x](https://github.com/user-attachments/assets/054906e4-ac61-4b5f-ad91-75d8c97e155d)

