### PR TITLE
Update pre-provision-accounts.md

### DIFF
--- a/SharePoint/SharePointOnline/pre-provision-accounts.md
+++ b/SharePoint/SharePointOnline/pre-provision-accounts.md
@@ -91,7 +91,7 @@ To verify that OneDrive has been created for your users, see [Get a list of all 
 
 The following code snippet will pre-provision OneDrive in batches of 199.
 > [!NOTE]
-> you need to provide your Microsoft 365 Tenant ID for more information see [Find IDs and domain names](https://learn.microsoft.com/en-us/partner-center/account-settings/find-ids-and-domain-names).
+> you need to provide your Microsoft 365 Tenant ID for more information see [Find IDs and domain names](https://learn.microsoft.com/vsts/partner-center/account-settings/find-ids-and-domain-names).
 
 
 ```PowerShell

--- a/SharePoint/SharePointOnline/pre-provision-accounts.md
+++ b/SharePoint/SharePointOnline/pre-provision-accounts.md
@@ -90,44 +90,50 @@ To verify that OneDrive has been created for your users, see [Get a list of all 
 ## Pre-provision OneDrive for all licensed users in your organization
 
 The following code snippet will pre-provision OneDrive in batches of 199.
+> [!NOTE]
+> you need to provide your Microsoft 365 Tenant ID for more information see [Find IDs and domain names](https://learn.microsoft.com/en-us/partner-center/account-settings/find-ids-and-domain-names).
+
 
 ```PowerShell
-$Credential = Get-Credential
-Connect-MgGraph -Credential $Credential
-Connect-SPOService -Credential $Credential -Url https://contoso-admin.sharepoint.com
+Param(
+    [Parameter(Mandatory = $True)]
+    [String]
+    $SharepointURL,
+    [Parameter(Mandatory = $True)]
+    [String]
+    $tenantID
+)
 
-$list = @()
-#Counters
-$i = 0
-$j = 0
+$scope = 'User.Read.All'
+Connect-MgGraph -TenantId $tenantId -Scopes $scope
+Connect-SPOService -Url $SharepointURL;
+
+$list = @() #list of UPN to pass to the SP command
+$Totalusers = 0 #total user provisioned.
 
 #Get licensed users
-$users = Get-MgUser -All | Where-Object { $_.islicensed -eq $true }
-#total licensed users
-$count = $users.count
+$users = Get-MgUser -Filter 'assignedLicenses/$count ne 0' -ConsistencyLevel eventual -CountVariable licensedUserCount -All -Select UserPrincipalName
 
 foreach ($u in $users) {
-    $i++
-    $j++
-    Write-Host "$j/$count"
+    $Totalusers++
+    Write-Host "$Totalusers/$($users.Count)"
+    $list += $u.userprincipalname
 
-    $upn = $u.userprincipalname
-    $list += $upn
-
-    if ($i -eq 199) {
+    if ($list.Count -eq 199) {
         #We reached the limit
         Write-Host "Batch limit reached, requesting provision for the current batch"
         Request-SPOPersonalSite -UserEmails $list -NoWait
         Start-Sleep -Milliseconds 655
         $list = @()
-        $i = 0
     }
 }
 
-if ($i -gt 0) {
+if ($list.Count -gt 0) {
     Request-SPOPersonalSite -UserEmails $list -NoWait
 }
-Write-Host "Completed OneDrive Provisioning for $j users"
+Disconnect-SPOService
+Disconnect-MgGraph
+Write-Host "Completed OneDrive Provisioning for $Totalusers users"
 ```
 
 ## Related topics


### PR DESCRIPTION
updating the code snippet. 
the previous code snippet will not work with Graph Cmdlets as the commands used have changed and require significant changes to the parameters, furthermore there are strong arguments on regards of security on regards of authentication with the previous script. (if they were to work) 

the previous code will fail to work with the following errors: 

Connect-MgGraph : Tenant id cannot be null. 
Connect-SPOService : One or more errors occurred.
At line:3 char:1
+ Connect-SPOService -Credential $Credential -Url ... Get-MgUser : Authentication needed. Please call Connect-MgGraph.

also, the usage of credentials is discouraged (if not plainly disabled at this point) you should use MSAL/Oauth instead. and to do so you don't need to provide the "-Credential" 

the new script corrects this nuance and include the Tenant flag. also remove the variable for the URL from Contoso to a parameter so the User of the script can provide the value without changing the script. 

if need be, an example usage can be provided such as 


$SharepointURL = "https://contoso.sharepoint.com"
$tenantID = "xxxx.xxxx.xxx"
.\script.ps1 -SharepointURL $SharepointURL -tenantID $tenantID