### PR TITLE
Removed the description of the private CDN

### DIFF
--- a/SharePoint/SharePointOnline/organization-assets-library.md
+++ b/SharePoint/SharePointOnline/organization-assets-library.md
@@ -77,20 +77,20 @@ If your organization needs to store and manage files for all your users to use, 
 6. Run the following command to designate the document library as an organization assets library:
 
     ```PowerShell
-    Add-SPOOrgAssetsLibrary -LibraryUrl <URL> [-ThumbnailUrl <URL>] [-OrgAssetType <ImageDocumentLibrary or OfficeTemplateLibrary>] [-CdnType <Public or Private>]
+    Add-SPOOrgAssetsLibrary -LibraryUrl <URL> [-ThumbnailUrl <URL>] [-OrgAssetType <ImageDocumentLibrary or OfficeTemplateLibrary>] -CdnType Public
     ```
 
    - *LibraryURL* is the absolute URL of the library to be designated as a central location for organization assets.
    - *ThumbnailURL* is the URL for the image file that you want to appear in the card's background in the file picker; this image must be on the same site as the library. The name publicly displayed for the library will be the organization's name.
    - *OrgAssetType* is either `ImageDocumentLibrary` or `OfficeTemplateLibrary`. If you don't specify the *OrgAssetType*, the library will be designated as an image library by default.
-   - If you don't specify the *CdnType*, it will enable a private CDN by default.
+   - *CdnType* is required to be set to Public
 
    [Learn more about the Add-SPOOrgAssetsLibrary cmdlet](/powershell/module/sharepoint-online/add-spoorgassetslibrary).
 
    Example:
 
    ```powershell
-   Add-SPOOrgAssetsLibrary -LibraryURL https://contoso.sharepoint.com/sites/branding/Assets -ThumbnailURL https://contoso.sharepoint.com/sites/branding/Assets/contosologo.jpg -OrgAssetType ImageDocumentLibrary
+   Add-SPOOrgAssetsLibrary -LibraryURL https://contoso.sharepoint.com/sites/branding/Assets -ThumbnailURL https://contoso.sharepoint.com/sites/branding/Assets/contosologo.jpg -OrgAssetType ImageDocumentLibrary -CdnType Public
    ```
 
 > [!NOTE]


### PR DESCRIPTION
Based on my understanding, the configuration of a Private CDN for SharePoint Online (Office 365 CDN)  has not been supported since the release of MC504326 in 2023.

MC504326 Configuration of Private CDN is no longer required for SharePoint Online.

However, the current tutorial for configuring an organization assets library still includes references to Private CDN, which may lead to unsupported configurations. To prevent potential misconfigurations, I suggest removing all mentions of Private CDN and explicitly requiring the -CdnType parameter to be set to Public.

If Private CDN is still exceptionally supported for organization assets libraries, a clear note should be added to distinguish this from other features where Private CDN is deprecated.


For reference, the documentation for Add-SPOOrgAssetsLibrary indicates that Private CDN support is deprecated. 

https://learn.microsoft.com/en-us/powershell/module/sharepoint-online/add-spoorgassetslibrary?view=sharepoint-ps#parameters

![image](https://github.com/user-attachments/assets/702ee205-f7e9-466d-984b-04a240e7e9c8)

Additionally, one of the most frequently cited articles on Office 365 CDN removed all references to Private CDN as of April 19, 2024.
https://learn.microsoft.com/en-us/microsoft-365/enterprise/office-365-cdn-quickstart?view=o365-worldwide#cdn-overview
![image](https://github.com/user-attachments/assets/ef830dfb-2ab5-49cd-a33e-7ccd8f6df816)

This is commit history for the above.
https://github.com/MicrosoftDocs/microsoft-365-docs/commit/44bd133df9e45b103189cbb40c421bcf6081ab0d
![image](https://github.com/user-attachments/assets/747ea05a-9141-4295-b17c-814add511e85)
